### PR TITLE
Removed passing an hardcoded port in the switches

### DIFF
--- a/netman/adapters/switches/brocade.py
+++ b/netman/adapters/switches/brocade.py
@@ -40,12 +40,16 @@ class Brocade(SwitchBase):
         self.shell = None
 
     def connect(self):
-        self.shell = self.shell_factory(
+        shell_params = dict(
             host=self.switch_descriptor.hostname,
             username=self.switch_descriptor.username,
             password=self.switch_descriptor.password,
-            port=self.switch_descriptor.port or 22
         )
+        if self.switch_descriptor.port:
+            shell_params["port"] = self.switch_descriptor.port
+
+        self.shell = self.shell_factory(**shell_params)
+
         if self.shell.get_current_prompt().endswith(">"):
             self.shell.do("enable", wait_for=":")
             self.shell.do(self.switch_descriptor.password)

--- a/netman/adapters/switches/cisco.py
+++ b/netman/adapters/switches/cisco.py
@@ -47,12 +47,16 @@ class Cisco(SwitchBase):
         self.ssh = None
 
     def connect(self):
-        self.ssh = ssh.SshClient(
+        params = dict(
             host=self.switch_descriptor.hostname,
             username=self.switch_descriptor.username,
             password=self.switch_descriptor.password,
-            port=self.switch_descriptor.port or 22
         )
+        if self.switch_descriptor.port:
+            params["port"] = self.switch_descriptor.port
+
+        self.ssh = ssh.SshClient(**params)
+
         if self.ssh.get_current_prompt().endswith(">"):
             self.ssh.do("enable", wait_for=": ")
             self.ssh.do(self.switch_descriptor.password)

--- a/netman/adapters/switches/dell.py
+++ b/netman/adapters/switches/dell.py
@@ -52,12 +52,16 @@ class Dell(SwitchBase):
         self.shell_factory = shell_factory
 
     def connect(self):
-        self.shell = self.shell_factory(
+        params = dict(
             host=self.switch_descriptor.hostname,
             username=self.switch_descriptor.username,
             password=self.switch_descriptor.password,
-            port=self.switch_descriptor.port or 22
         )
+
+        if self.switch_descriptor.port:
+            params["port"] = self.switch_descriptor.port
+
+        self.shell = self.shell_factory(**params)
 
         self.shell.do("enable", wait_for=":")
         self.shell.do(self.switch_descriptor.password)

--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -41,15 +41,19 @@ class Juniper(SwitchBase):
         self.in_transaction = False
 
     def connect(self):
-        self.netconf = manager.connect(
+        params = dict(
             host=self.switch_descriptor.hostname,
             username=self.switch_descriptor.username,
             password=self.switch_descriptor.password,
             hostkey_verify=False,
             device_params={'name': 'junos'},
-            port=self.switch_descriptor.port or 830,
             timeout=self.timeout
         )
+
+        if self.switch_descriptor.port:
+            params["port"] = self.switch_descriptor.port
+
+        self.netconf = manager.connect(**params)
 
     def disconnect(self):
         try:

--- a/tests/adapters/switches/dell10g_test.py
+++ b/tests/adapters/switches/dell10g_test.py
@@ -74,7 +74,7 @@ class Dell10GTest(unittest.TestCase):
     @mock.patch("netman.adapters.shell.ssh.SshClient")
     def test_connect(self, ssh_client_class_mock):
         self.switch = Dell10G(
-            SwitchDescriptor(hostname="my.hostname", username="the_user", password="the_password", model="dell"),
+            SwitchDescriptor(hostname="my.hostname", username="the_user", password="the_password", model="dell", port=22),
             shell_factory=ssh_client_class_mock)
 
         self.mocked_ssh_client = flexmock()
@@ -90,6 +90,26 @@ class Dell10GTest(unittest.TestCase):
             username="the_user",
             password="the_password",
             port=22
+        )
+
+    @mock.patch("netman.adapters.shell.telnet.TelnetClient")
+    def test_connect_without_port_uses_default(self, ssh_client_class_mock):
+        self.switch = Dell10G(
+            SwitchDescriptor(hostname="my.hostname", username="the_user", password="the_password", model="dell"),
+            shell_factory=ssh_client_class_mock)
+
+        self.mocked_ssh_client = flexmock()
+        ssh_client_class_mock.return_value = self.mocked_ssh_client
+        self.mocked_ssh_client.should_receive("do").with_args("enable", wait_for=":").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("the_password").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("terminal length 0").and_return([]).once().ordered()
+
+        self.switch.connect()
+
+        ssh_client_class_mock.assert_called_with(
+            host="my.hostname",
+            username="the_user",
+            password="the_password"
         )
 
     def test_disconnect(self):

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -4730,6 +4730,25 @@ class JuniperTest(unittest.TestCase):
             timeout=120
         )
 
+    @mock.patch("ncclient.manager.connect")
+    def test_connect_without_port_uses_default(self, connect_mock):
+        connect_mock.return_value = self.netconf_mock
+
+        self.switch = Juniper(
+            SwitchDescriptor(model='juniper', hostname="toto", username="tutu", password="titi"),
+            custom_strategies=JuniperCustomStrategies(), timeout=120)
+
+        self.switch.connect()
+
+        connect_mock.assert_called_with(
+            host="toto",
+            username="tutu",
+            password="titi",
+            hostkey_verify=False,
+            device_params={'name':'junos'},
+            timeout=120
+        )
+
     def test_disconnect(self):
         self.netconf_mock.should_receive("close_session").once().ordered()
 


### PR DESCRIPTION
This way the protocols decide their own default ports
ssh=22, telnet=23, netconf=830