### PR TITLE
Refactored adapter tests

### DIFF
--- a/tests/adapters/switches/brocade_backward_compatibility_test.py
+++ b/tests/adapters/switches/brocade_backward_compatibility_test.py
@@ -26,7 +26,7 @@ from tests.adapters.switches.brocade_test import vlan_with_vif_display, vlan_dis
 class BrocadeBackwardCompatibilityTest(unittest.TestCase):
 
     def setUp(self):
-        self.switch = BackwardCompatibleBrocade(SwitchDescriptor("cisco", "host"), None)
+        self.switch = BackwardCompatibleBrocade(SwitchDescriptor("brocade", "host"), None)
         self.shell_mock = flexmock()
         self.switch.shell = self.shell_mock
 

--- a/tests/adapters/switches/brocade_backward_compatibility_test.py
+++ b/tests/adapters/switches/brocade_backward_compatibility_test.py
@@ -14,32 +14,28 @@
 
 import unittest
 
-from netman.adapters.switches.util import SubShell
-from tests.adapters.switches.brocade_test import vlan_with_vif_display, vlan_display
 from flexmock import flexmock, flexmock_teardown
-import mock
 from netaddr.ip import IPAddress
-from netman.adapters.switches import brocade_factory_ssh
+
+from netman.adapters.switches.backward_compatible_brocade import BackwardCompatibleBrocade
+from netman.adapters.switches.util import SubShell
 from netman.core.objects.switch_descriptor import SwitchDescriptor
+from tests.adapters.switches.brocade_test import vlan_with_vif_display, vlan_display
 
 
 class BrocadeBackwardCompatibilityTest(unittest.TestCase):
 
     def setUp(self):
-        self.lock = mock.Mock()
-        self.switch = brocade_factory_ssh(SwitchDescriptor(model='brocade', hostname="my.hostname"), self.lock)
+        self.switch = BackwardCompatibleBrocade(SwitchDescriptor("cisco", "host"), None)
+        self.shell_mock = flexmock()
+        self.switch.shell = self.shell_mock
+
         SubShell.debug = True
 
     def tearDown(self):
         flexmock_teardown()
 
-    def command_setup(self):
-        self.shell_mock = flexmock()
-        self.switch.impl.shell = self.shell_mock
-
     def test_set_access_vlan_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan 2999").once().ordered().and_return(
             vlan_display(2999)
         )
@@ -48,13 +44,10 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
         self.shell_mock.should_receive("do").with_args("vlan 2999").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("untagged ethernet 1/4").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.set_access_vlan("1/4", vlan=2999)
 
     def test_remove_access_vlan_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan brief | include ethe 1/4").once().ordered().and_return([
             "1202     your-name-                                        1202  -  Untagged Ports : ethe 1/10"
         ])
@@ -63,13 +56,10 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
         self.shell_mock.should_receive("do").with_args("vlan 1202").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("no untagged ethernet 1/4").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.remove_access_vlan("1/4")
 
     def test_set_access_mode_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan ethernet 1/4").once().ordered().and_return([
             "VLAN: 100  Tagged",
             "VLAN: 300  Untagged",
@@ -81,25 +71,19 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
         self.shell_mock.should_receive("do").with_args("vlan 300").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("no untagged ethernet 1/4").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.set_access_mode("1/4")
 
     def test_set_trunk_mode_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan ethernet 1/4").once().ordered().and_return([
             "VLAN: 1  Untagged"
         ])
 
         self.shell_mock.should_receive("do").with_args("configure terminal").never()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.set_trunk_mode("1/4")
 
     def test_add_trunk_vlan_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan 2999").once().ordered().and_return(
             vlan_display(2999)
         )
@@ -108,13 +92,10 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
         self.shell_mock.should_receive("do").with_args("vlan 2999").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("tagged ethernet 1/1").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.add_trunk_vlan("1/1", vlan=2999)
 
     def test_remove_trunk_vlan_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan 2999").once().ordered().and_return(
             vlan_display(2999)
         )
@@ -123,35 +104,26 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
         self.shell_mock.should_receive("do").with_args("vlan 2999").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("no tagged ethernet 1/11").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.remove_trunk_vlan("1/11", vlan=2999)
 
     def test_shutdown_interface_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
         self.shell_mock.should_receive("do").with_args("interface ethernet 1/4").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("disable").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.shutdown_interface("1/4")
 
     def test_openup_interface_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
         self.shell_mock.should_receive("do").with_args("interface ethernet 1/4").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("enable").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.openup_interface("1/4")
 
     def test_configure_native_vlan_backward_compatibility(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan 2999").once().ordered().and_return(
             vlan_display(2999)
         )
@@ -160,13 +132,10 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
         self.shell_mock.should_receive("do").with_args("vlan 2999").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("untagged ethernet 1/4").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.configure_native_vlan("1/4", vlan=2999)
 
     def test_remove_native_vlan_on_trunk_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan brief | include ethe 1/4").once().ordered().and_return([
             "1202     your-name-                                        1202  -  Untagged Ports : ethe 1/10"
         ])
@@ -175,13 +144,10 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
         self.shell_mock.should_receive("do").with_args("vlan 1202").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("no untagged ethernet 1/4").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.remove_native_vlan("1/4")
 
     def test_add_vrrp_accepts_no_ethernet(self):
-        self.command_setup()
-
         self.shell_mock.should_receive("do").with_args("show vlan 1234").once().ordered().and_return(
             vlan_with_vif_display(1234, 1234)
         )
@@ -204,7 +170,6 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
         self.shell_mock.should_receive("do").with_args("track-port ethernet 1/1").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("activate").and_return([]).once().ordered()
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
-        self.shell_mock.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
         self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                    track_id="1/1", track_decrement=50)

--- a/tests/adapters/switches/dell10g_test.py
+++ b/tests/adapters/switches/dell10g_test.py
@@ -205,8 +205,6 @@ class Dell10GTest(unittest.TestCase):
         assert_that(len(vlan4000.ips), equal_to(0))
 
     def test_get_vlan_with_no_name(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000").once().ordered().and_return([
 
             "VLAN   Name                             Ports          Type",
@@ -224,8 +222,6 @@ class Dell10GTest(unittest.TestCase):
         assert_that(len(vlan.ips), equal_to(0))
 
     def test_get_vlan_standard_with_name(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000").once().ordered().and_return([
 
             "VLAN   Name                             Ports          Type",
@@ -243,8 +239,6 @@ class Dell10GTest(unittest.TestCase):
         assert_that(len(vlan.ips), equal_to(0))
 
     def test_get_vlan_default(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1").once().ordered().and_return([
 
             "VLAN   Name                             Ports          Type",
@@ -262,8 +256,6 @@ class Dell10GTest(unittest.TestCase):
         assert_that(len(vlan.ips), equal_to(0))
 
     def test_get_vlan_with_value_out_of_range(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 5000").once().ordered().and_return([
             "                                              ^",
             "Value is out of range. The valid range is 1 to 4093."
@@ -275,8 +267,6 @@ class Dell10GTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan number is invalid"))
 
     def test_get_vlan_with_bad_number(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id abcde").once().ordered().and_return([
             "                                              ^",
             "Invalid input. Please specify an integer in the range 1 to 4093."
@@ -288,8 +278,6 @@ class Dell10GTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan number is invalid"))
 
     def test_get_vlan_with_unknown_number(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1210").once().ordered().and_return([
             "ERROR: This VLAN does not exist."
         ])

--- a/tests/adapters/switches/dell_test.py
+++ b/tests/adapters/switches/dell_test.py
@@ -232,8 +232,6 @@ class DellTest(unittest.TestCase):
         assert_that(vlans, has_length(10))
 
     def test_get_vlan_standard_no_name(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "VLAN       Name                         Ports          Type      Authorization",
             "-----  ---------------                  -------------  -----     -------------",
@@ -249,8 +247,6 @@ class DellTest(unittest.TestCase):
         assert_that(len(vlan.ips), equal_to(0))
 
     def test_get_vlan_with_name(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "VLAN       Name                         Ports          Type      Authorization",
             "-----  ---------------                  -------------  -----     -------------",
@@ -266,8 +262,6 @@ class DellTest(unittest.TestCase):
         assert_that(len(vlan.ips), equal_to(0))
 
     def test_get_vlan_default(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "VLAN       Name                         Ports          Type      Authorization",
             "-----  ---------------                  -------------  -----     -------------",
@@ -291,8 +285,6 @@ class DellTest(unittest.TestCase):
         assert_that(len(vlan.ips), equal_to(0))
 
     def test_get_vlan_with_bad_number(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 5000", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "                     ^",
             "Invalid input. Please specify an integer in the range 1 to 4093."
@@ -304,8 +296,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan number is invalid"))
 
     def test_get_vlan_with_unknown_number(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 2019", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "ERROR: This VLAN does not exist."
         ])
@@ -316,8 +306,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan None not found"))
 
     def test_get_vlan_with_more_than_one_page(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "VLAN       Name                         Ports          Type      Authorization",
             "-----  ---------------                  -------------  -----     -------------",

--- a/tests/adapters/switches/dell_test.py
+++ b/tests/adapters/switches/dell_test.py
@@ -58,16 +58,13 @@ def test_factory_telnet():
 class DellTest(unittest.TestCase):
 
     def setUp(self):
-        self.lock = mock.Mock()
-        self.switch = dell.factory_ssh(SwitchDescriptor(model='dell', hostname="my.hostname", password="the_password"), self.lock)
+        self.switch = Dell(SwitchDescriptor(model='dell', hostname="my.hostname", password="the_password"), None)
         SubShell.debug = True
+        self.mocked_ssh_client = flexmock()
+        self.switch.shell = self.mocked_ssh_client
 
     def tearDown(self):
         flexmock_teardown()
-
-    def command_setup(self):
-        self.mocked_ssh_client = flexmock()
-        self.switch.impl.shell = self.mocked_ssh_client
 
     def test_switch_has_a_logger_configured_with_the_switch_name(self):
         assert_that(self.switch.logger.name, is_(Dell.__module__ + ".my.hostname"))
@@ -113,21 +110,19 @@ class DellTest(unittest.TestCase):
 
     def test_disconnect(self):
         logger = flexmock()
-        self.switch.impl.logger = logger
+        self.switch.logger = logger
         logger.should_receive("debug")
 
         mocked_ssh_client = flexmock()
-        self.switch.impl.shell = mocked_ssh_client
+        self.switch.shell = mocked_ssh_client
         mocked_ssh_client.should_receive("quit").with_args("quit").once().ordered()
 
         logger.should_receive("info").with_args("FULL TRANSACTION LOG").once()
 
-        self.switch.impl.shell.full_log = "FULL TRANSACTION LOG"
+        self.switch.shell.full_log = "FULL TRANSACTION LOG"
         self.switch.disconnect()
 
     def test_shutdown_interface(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g4").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("shutdown").once().ordered().and_return([])
@@ -136,8 +131,6 @@ class DellTest(unittest.TestCase):
         self.switch.shutdown_interface("ethernet 1/g4")
 
     def test_shutdown_interface_invalid_interface_raises(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("configure").once().ordered().and_return([])
         self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 99/g99").once().ordered().and_return([
             "An invalid interface has been used for this function."
@@ -150,8 +143,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 99/g99"))
 
     def test_openup_interface(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g4").and_return([]).once().ordered()
             self.mocked_ssh_client.should_receive("do").with_args("no shutdown").and_return([]).once().ordered()
@@ -160,8 +151,6 @@ class DellTest(unittest.TestCase):
         self.switch.openup_interface("ethernet 1/g4")
 
     def test_openup_interface_invalid_interface_raises(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("configure").once().ordered().and_return([])
         self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 99/g99").once().ordered().and_return([
             "An invalid interface has been used for this function."
@@ -174,8 +163,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 99/g99"))
 
     def test_get_vlans(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "VLAN       Name                         Ports          Type      Authorization",
             "-----  ---------------                  -------------  -----     -------------",
@@ -211,8 +198,6 @@ class DellTest(unittest.TestCase):
         assert_that(len(vlan4000.ips), equal_to(0))
 
     def test_get_vlans_multipage(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "VLAN       Name                         Ports          Type      Authorization",
             "-----  ---------------                  -------------  -----     -------------",
@@ -247,8 +232,6 @@ class DellTest(unittest.TestCase):
         assert_that(vlans, has_length(10))
 
     def test_get_interfaces(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show interfaces status", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).and_return([
             "Port   Type                            Duplex  Speed    Neg  Link  Flow Control",
             "                                                             State Status",
@@ -314,8 +297,6 @@ class DellTest(unittest.TestCase):
         assert_that(ch10.name, is_("port-channel 10"))
 
     def test_get_interfaces_multipage(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show interfaces status", wait_for=("--More-- or (q)uit", "#"), include_last_line=True).once().ordered().and_return([
             "Port   Type                            Duplex  Speed    Neg  Link  Flow Control",
             "                                                             State Status",
@@ -357,8 +338,6 @@ class DellTest(unittest.TestCase):
         assert_that(self.switch.get_interfaces(), has_length(8))
 
     def test_add_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000").and_return([
             "ERROR: This VLAN does not exist."
         ])
@@ -374,8 +353,6 @@ class DellTest(unittest.TestCase):
         self.switch.add_vlan(1000)
 
     def test_add_vlan_and_name(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000").and_return([
             "ERROR: This VLAN does not exist."
         ])
@@ -394,8 +371,6 @@ class DellTest(unittest.TestCase):
         self.switch.add_vlan(1000, name="shizzle")
 
     def test_add_vlan_invalid_number(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 5000").and_return([
             "                     ^",
             "Invalid input. Please specify an integer in the range 1 to 4093."
@@ -407,8 +382,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan number is invalid"))
 
     def test_add_vlan_and_bad_name(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000").and_return([
             "ERROR: This VLAN does not exist."
         ])
@@ -433,8 +406,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan name is invalid"))
 
     def test_add_vlan_fails_when_already_exist(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show vlan id 1000").and_return([
             "VLAN       Name                         Ports          Type      Authorization",
             "-----  ---------------                  -------------  -----     -------------",
@@ -447,8 +418,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan 1000 already exists"))
 
     def test_remove_vlan(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("vlan database").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("no vlan 1000").once().ordered().and_return([
@@ -462,8 +431,6 @@ class DellTest(unittest.TestCase):
         self.switch.remove_vlan(1000)
 
     def test_remove_unknown_vlan(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("vlan database").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("no vlan 1000").once().ordered().and_return([
@@ -479,8 +446,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan 1000 not found"))
 
     def test_set_access_mode(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("switchport mode access").once().ordered().and_return([])
@@ -489,8 +454,6 @@ class DellTest(unittest.TestCase):
         self.switch.set_access_mode("ethernet 1/g10")
 
     def test_set_access_mode_invalid_interface(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g99").once().ordered().and_return([
                 "An invalid interface has been used for this function."
@@ -502,8 +465,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_set_bond_access_mode(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("switchport mode access").once().ordered().and_return([])
@@ -512,8 +473,6 @@ class DellTest(unittest.TestCase):
         self.switch.set_bond_access_mode(10)
 
     def test_set_bond_access_mode_invalid_interface(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 99999").once().ordered().and_return([
                 "An invalid interface has been used for this function."
@@ -525,8 +484,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Bond 99999 not found"))
 
     def test_set_trunk_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
         ])
 
@@ -538,34 +495,24 @@ class DellTest(unittest.TestCase):
         self.switch.set_trunk_mode("ethernet 1/g10")
 
     def test_set_trunk_mode_stays_in_trunk(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode trunk"
         ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
-        self.mocked_ssh_client.should_receive("do").with_args("copy running-config startup-config", wait_for="? (y/n) ").once().ordered().and_return([])
-        self.mocked_ssh_client.should_receive("send_key").with_args("y").once().ordered().and_return([])
 
         self.switch.set_trunk_mode("ethernet 1/g10")
 
     def test_set_trunk_mode_stays_in_general(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode general"
         ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
-        self.mocked_ssh_client.should_receive("do").with_args("copy running-config startup-config", wait_for="? (y/n) ").once().ordered().and_return([])
-        self.mocked_ssh_client.should_receive("send_key").with_args("y").once().ordered().and_return([])
 
         self.switch.set_trunk_mode("ethernet 1/g10")
 
     def test_configure_set_trunk_mode_unknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g99").and_return([
             "ERROR: Invalid input!",
         ])
@@ -578,8 +525,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_set_bond_trunk_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
         ])
 
@@ -591,37 +536,27 @@ class DellTest(unittest.TestCase):
         self.switch.set_bond_trunk_mode(10)
 
     def test_set_bond_trunk_mode_stays_in_bond_trunk(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode trunk"
         ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
-        self.mocked_ssh_client.should_receive("do").with_args("copy running-config startup-config", wait_for="? (y/n) ").once().ordered().and_return([])
-        self.mocked_ssh_client.should_receive("send_key").with_args("y").once().ordered().and_return([])
 
         self.switch.set_bond_trunk_mode(10)
 
     def test_set_bond_trunk_mode_stays_in_general(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode general"
         ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
-        self.mocked_ssh_client.should_receive("do").with_args("copy running-config startup-config", wait_for="? (y/n) ").once().ordered().and_return([])
-        self.mocked_ssh_client.should_receive("send_key").with_args("y").once().ordered().and_return([])
 
         self.switch.set_bond_trunk_mode(10)
 
     def test_configure_set_bond_trunk_mode_unknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 999999").and_return([
             "ERROR: Invalid input!",
-            ])
+        ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
 
@@ -631,8 +566,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Bond 999999 not found"))
 
     def test_set_access_vlan(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("switchport access vlan 1000").once().ordered().and_return([
@@ -644,8 +577,6 @@ class DellTest(unittest.TestCase):
         self.switch.set_access_vlan("ethernet 1/g10", 1000)
 
     def test_set_access_vlan_invalid_interface(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g99").once().ordered().and_return([
                 "An invalid interface has been used for this function."
@@ -657,7 +588,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_set_access_vlan_invalid_vlan(self):
-        self.command_setup()
 
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
@@ -674,8 +604,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan 1000 not found"))
 
     def test_set_access_vlan_invalid_mode(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("switchport access vlan 1000").once().ordered().and_return([
@@ -691,8 +619,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Operation cannot be performed on a trunk mode interface"))
 
     def test_remove_access_vlan(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("no switchport access vlan").once().ordered().and_return([
@@ -704,8 +630,6 @@ class DellTest(unittest.TestCase):
         self.switch.remove_access_vlan("ethernet 1/g10")
 
     def test_remove_access_vlan_invalid_interface(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g99").once().ordered().and_return([
                 "An invalid interface has been used for this function."
@@ -717,7 +641,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_configure_native_vlan_on_a_general_interface(self):
-        self.command_setup()
 
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode general"
@@ -731,8 +654,6 @@ class DellTest(unittest.TestCase):
         self.switch.configure_native_vlan("ethernet 1/g10", 1000)
 
     def test_configure_native_vlan_unknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g99").and_return([
             "ERROR: Invalid input!",
         ])
@@ -745,8 +666,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_configure_native_vlan_unknown_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode general",
         ])
@@ -764,8 +683,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan 1000 not found"))
 
     def test_configure_native_vlan_on_an_unknown_mode_with_no_access_vlan_assume_not_set_and_set_port_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
         ])
 
@@ -778,8 +695,6 @@ class DellTest(unittest.TestCase):
         self.switch.configure_native_vlan("ethernet 1/g10", 1000)
 
     def test_configure_native_vlan_on_an_unknown_mode_with_an_access_vlan_assume_access_mode_and_fails(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport access vlan 2000",
         ])
@@ -792,8 +707,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Operation cannot be performed on a access mode interface"))
 
     def test_configure_native_vlan_on_a_trunk_mode_swithes_to_general(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode trunk",
         ])
@@ -807,8 +720,6 @@ class DellTest(unittest.TestCase):
         self.switch.configure_native_vlan("ethernet 1/g10", 1000)
 
     def test_configure_native_vlan_on_a_trunk_mode_swithes_to_general_and_copies_actual_allowed_vlans(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode trunk",
             "switchport trunk allowed vlan add 1201-1203,1205",
@@ -824,8 +735,6 @@ class DellTest(unittest.TestCase):
         self.switch.configure_native_vlan("ethernet 1/g10", 1000)
 
     def test_remove_native_vlan_reverts_to_trunk_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode general",
             "switchport general pvid 1000"
@@ -839,8 +748,6 @@ class DellTest(unittest.TestCase):
         self.switch.remove_native_vlan("ethernet 1/g10")
 
     def test_remove_native_vlan_reverts_to_trunk_mode_and_keeps_allowed_vlans_specs(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode general",
             "switchport general pvid 1000",
@@ -856,8 +763,6 @@ class DellTest(unittest.TestCase):
         self.switch.remove_native_vlan("ethernet 1/g10")
 
     def test_remove_native_vlan_inknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g99").and_return([
             "ERROR: Invalid input!",
         ])
@@ -870,8 +775,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_remove_native_vlan_not_set(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode general"
         ])
@@ -884,8 +787,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), is_("Trunk native Vlan is not set on interface ethernet 1/g10"))
 
     def test_remove_bond_native_vlan_reverts_to_trunk_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode general",
             "switchport general pvid 1000"
@@ -899,13 +800,11 @@ class DellTest(unittest.TestCase):
         self.switch.remove_bond_native_vlan(10)
 
     def test_remove_bond_native_vlan_reverts_to_trunk_mode_and_keeps_allowed_vlans_specs(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode general",
             "switchport general pvid 1000",
             "switchport general allowed vlan add 1201-1203,1205",
-            ])
+        ])
 
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -916,22 +815,18 @@ class DellTest(unittest.TestCase):
         self.switch.remove_bond_native_vlan(10)
 
     def test_remove_bond_native_vlan_inknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 99999").and_return([
             "ERROR: Invalid input!",
             ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
 
-        with self.assertRaises(UnknownInterface) as expect:
+        with self.assertRaises(UnknownBond) as expect:
             self.switch.remove_bond_native_vlan(99999)
 
-        assert_that(str(expect.exception), equal_to("Unknown interface port-channel 99999"))
+        assert_that(str(expect.exception), equal_to("Bond 99999 not found"))
 
     def test_remove_bond_native_vlan_not_set(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode general"
         ])
@@ -944,8 +839,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), is_("Trunk native Vlan is not set on interface port-channel 10"))
 
     def test_configure_bond_native_vlan_on_a_general_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode general"
         ])
@@ -958,11 +851,10 @@ class DellTest(unittest.TestCase):
         self.switch.configure_bond_native_vlan(10, 1000)
 
     def test_configure_bond_native_vlan_unknown_interface(self):
-        self.command_setup()
 
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 99999").and_return([
             "ERROR: Invalid input!",
-            ])
+        ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
 
@@ -972,11 +864,9 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Bond 99999 not found"))
 
     def test_configure_bond_native_vlan_unknown_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode general",
-            ])
+        ])
 
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -991,8 +881,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan 1000 not found"))
 
     def test_configure_bond_native_vlan_on_an_unknown_mode_with_no_access_vlan_assume_not_set_and_set_port_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
         ])
 
@@ -1005,11 +893,9 @@ class DellTest(unittest.TestCase):
         self.switch.configure_bond_native_vlan(10, 1000)
 
     def test_configure_bond_native_vlan_on_an_unknown_mode_with_an_access_vlan_assume_access_mode_and_fails(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport access vlan 2000",
-            ])
+        ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
 
@@ -1019,11 +905,9 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Operation cannot be performed on a access mode interface"))
 
     def test_configure_bond_native_vlan_on_a_trunk_mode_swithes_to_general(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode trunk",
-            ])
+        ])
 
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -1034,12 +918,10 @@ class DellTest(unittest.TestCase):
         self.switch.configure_bond_native_vlan(10, 1000)
 
     def test_configure_bond_native_vlan_on_a_trunk_mode_swithes_to_general_and_copies_actual_allowed_vlans(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode trunk",
             "switchport trunk allowed vlan add 1201-1203,1205",
-            ])
+        ])
 
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -1050,69 +932,7 @@ class DellTest(unittest.TestCase):
 
         self.switch.configure_bond_native_vlan(10, 1000)
 
-    def test_remove_bond_native_vlan_reverts_to_trunk_mode(self):
-        self.command_setup()
-
-        self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
-            "switchport mode general",
-            "switchport general pvid 1000"
-        ])
-
-        with self.configuring_and_committing():
-            self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
-            self.mocked_ssh_client.should_receive("do").with_args("switchport mode trunk").once().ordered().and_return([])
-            self.mocked_ssh_client.should_receive("do").with_args("exit").once().ordered().and_return([])
-
-        self.switch.remove_bond_native_vlan(10)
-
-    def test_remove_bond_native_vlan_reverts_to_trunk_mode_and_keeps_allowed_vlans_specs(self):
-        self.command_setup()
-
-        self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
-            "switchport mode general",
-            "switchport general pvid 1000",
-            "switchport general allowed vlan add 1201-1203,1205",
-            ])
-
-        with self.configuring_and_committing():
-            self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
-            self.mocked_ssh_client.should_receive("do").with_args("switchport mode trunk").once().ordered().and_return([])
-            self.mocked_ssh_client.should_receive("do").with_args("switchport trunk allowed vlan add 1201-1203,1205").once().ordered().and_return([])
-            self.mocked_ssh_client.should_receive("do").with_args("exit").once().ordered().and_return([])
-
-        self.switch.remove_bond_native_vlan(10)
-
-    def test_remove_bond_native_vlan_inknown_interface(self):
-        self.command_setup()
-
-        self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 99999").and_return([
-            "ERROR: Invalid input!",
-            ])
-
-        self.mocked_ssh_client.should_receive("do").with_args("configure").never()
-
-        with self.assertRaises(UnknownBond) as expect:
-            self.switch.remove_bond_native_vlan(99999)
-
-        assert_that(str(expect.exception), equal_to("Bond 99999 not found"))
-
-    def test_remove_bond_native_vlan_not_set(self):
-        self.command_setup()
-
-        self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
-            "switchport mode general"
-        ])
-
-        self.mocked_ssh_client.should_receive("do").with_args("configure").never()
-
-        with self.assertRaises(NativeVlanNotSet) as expect:
-            self.switch.remove_bond_native_vlan(10)
-
-        assert_that(str(expect.exception), is_("Trunk native Vlan is not set on interface port-channel 10"))
-
     def test_add_trunk_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode trunk",
         ])
@@ -1128,8 +948,6 @@ class DellTest(unittest.TestCase):
         self.switch.add_trunk_vlan("ethernet 1/g10", 1000)
 
     def test_add_trunk_vlan_unknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g99").and_return([
             "ERROR: Invalid input!",
         ])
@@ -1142,8 +960,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_add_trunk_vlan_unknown_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode trunk",
         ])
@@ -1169,8 +985,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan 1000 not found"))
 
     def test_add_trunk_vlan_to_general_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode general",
         ])
@@ -1186,8 +1000,6 @@ class DellTest(unittest.TestCase):
         self.switch.add_trunk_vlan("ethernet 1/g10", 1000)
 
     def test_add_trunk_vlan_without_mode_and_access_vlan_assume_no_mode_set_trunk_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
         ])
 
@@ -1203,8 +1015,6 @@ class DellTest(unittest.TestCase):
         self.switch.add_trunk_vlan("ethernet 1/g10", 1000)
 
     def test_add_trunk_vlan_without_mode_with_access_vlan_assume_access_mode_and_fails(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport access vlan 2000",
         ])
@@ -1217,8 +1027,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Operation cannot be performed on a access mode interface"))
 
     def test_remove_trunk_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode trunk",
             "switchport trunk allowed vlan add 1000",
@@ -1235,8 +1043,6 @@ class DellTest(unittest.TestCase):
         self.switch.remove_trunk_vlan("ethernet 1/g10", 1000)
 
     def test_remove_trunk_vlan_unknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g99").and_return([
             "ERROR: Invalid input!",
         ])
@@ -1249,8 +1055,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_remove_trunk_vlan_not_set_at_all(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode trunk",
         ])
@@ -1261,8 +1065,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Trunk Vlan is not set on interface ethernet 1/g10"))
 
     def test_remove_trunk_vlan_not_set_in_ranges(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode trunk",
             "switchport trunk allowed vlan add 999,1001",
@@ -1274,8 +1076,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Trunk Vlan is not set on interface ethernet 1/g10"))
 
     def test_remove_trunk_vlan_general_mode_and_in_range(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g10").and_return([
             "switchport mode general",
             "switchport general allowed vlan add 999-1001",
@@ -1292,11 +1092,9 @@ class DellTest(unittest.TestCase):
         self.switch.remove_trunk_vlan("ethernet 1/g10", 1000)
 
     def test_add_bond_trunk_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode trunk",
-            ])
+        ])
 
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -1309,11 +1107,9 @@ class DellTest(unittest.TestCase):
         self.switch.add_bond_trunk_vlan(10, 1000)
 
     def test_add_bond_trunk_vlan_unknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 99").and_return([
             "ERROR: Invalid input!",
-            ])
+        ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
 
@@ -1323,11 +1119,9 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Bond 99 not found"))
 
     def test_add_bond_trunk_vlan_unknown_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode trunk",
-            ])
+        ])
 
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -1341,7 +1135,7 @@ class DellTest(unittest.TestCase):
                 "   VLAN             Error",
                 "---------------------------------------",
                 "VLAN      1000 ERROR: This VLAN does not exist.",
-                ])
+            ])
             self.mocked_ssh_client.should_receive("do").with_args("exit").once().ordered().and_return([])
 
         with self.assertRaises(UnknownVlan) as expect:
@@ -1350,11 +1144,9 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Vlan 1000 not found"))
 
     def test_add_bond_trunk_vlan_to_general_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode general",
-            ])
+        ])
 
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -1367,8 +1159,6 @@ class DellTest(unittest.TestCase):
         self.switch.add_bond_trunk_vlan(10, 1000)
 
     def test_add_bond_trunk_vlan_without_mode_and_access_vlan_assume_no_mode_set_trunk_mode(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
         ])
 
@@ -1384,11 +1174,9 @@ class DellTest(unittest.TestCase):
         self.switch.add_bond_trunk_vlan(10, 1000)
 
     def test_add_bond_trunk_vlan_without_mode_with_access_vlan_assume_access_mode_and_fails(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport access vlan 2000",
-            ])
+        ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
 
@@ -1398,12 +1186,10 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Operation cannot be performed on a access mode interface"))
 
     def test_remove_bond_trunk_vlan(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode trunk",
             "switchport trunk allowed vlan add 1000",
-            ])
+        ])
 
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -1416,11 +1202,9 @@ class DellTest(unittest.TestCase):
         self.switch.remove_bond_trunk_vlan(10, 1000)
 
     def test_remove_bond_trunk_vlan_unknown_interface(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 99").and_return([
             "ERROR: Invalid input!",
-            ])
+        ])
 
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
 
@@ -1430,11 +1214,9 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Bond 99 not found"))
 
     def test_remove_bond_trunk_vlan_not_set_at_all(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode trunk",
-            ])
+        ])
 
         with self.assertRaises(TrunkVlanNotSet) as expect:
             self.switch.remove_bond_trunk_vlan(10, 1000)
@@ -1442,12 +1224,10 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Trunk Vlan is not set on interface port-channel 10"))
 
     def test_remove_bond_trunk_vlan_not_set_in_ranges(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode trunk",
             "switchport trunk allowed vlan add 999,1001",
-            ])
+        ])
 
         with self.assertRaises(TrunkVlanNotSet) as expect:
             self.switch.remove_bond_trunk_vlan(10, 1000)
@@ -1455,12 +1235,10 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Trunk Vlan is not set on interface port-channel 10"))
 
     def test_remove_bond_trunk_vlan_general_mode_and_in_range(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface port-channel 10").and_return([
             "switchport mode general",
             "switchport general allowed vlan add 999-1001",
-            ])
+        ])
 
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
@@ -1473,8 +1251,6 @@ class DellTest(unittest.TestCase):
         self.switch.remove_bond_trunk_vlan(10, 1000)
 
     def test_edit_interface_spanning_tree_enable_edge(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("spanning-tree portfast").once().ordered().and_return([])
@@ -1483,8 +1259,6 @@ class DellTest(unittest.TestCase):
         self.switch.edit_interface_spanning_tree('ethernet 1/g10', edge=True)
 
     def test_edit_interface_spanning_tree_disable_edge(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("no spanning-tree portfast").once().ordered().and_return([])
@@ -1493,18 +1267,11 @@ class DellTest(unittest.TestCase):
         self.switch.edit_interface_spanning_tree('ethernet 1/g10', edge=False)
 
     def test_edit_interface_spanning_tree_optional_params(self):
-        self.command_setup()
-
         self.mocked_ssh_client.should_receive("do").with_args("configure").never()
-
-        self.mocked_ssh_client.should_receive("do").with_args("copy running-config startup-config", wait_for="? (y/n) ").once().ordered().and_return([])
-        self.mocked_ssh_client.should_receive("send_key").with_args("y").once().ordered().and_return([])
 
         self.switch.edit_interface_spanning_tree("ethernet 1/g10")
 
     def test_enable_lldp(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("lldp transmit").once().ordered().and_return([])
@@ -1516,8 +1283,6 @@ class DellTest(unittest.TestCase):
         self.switch.enable_lldp("ethernet 1/g10", True)
 
     def test_disable_lldp(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("no lldp transmit").once().ordered().and_return([])
@@ -1529,8 +1294,6 @@ class DellTest(unittest.TestCase):
         self.switch.enable_lldp("ethernet 1/g10", False)
 
     def test_set_interface_description(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("description \"Hey\"").once().ordered().and_return([])
@@ -1539,8 +1302,6 @@ class DellTest(unittest.TestCase):
         self.switch.set_interface_description("ethernet 1/g10", "Hey")
 
     def test_set_interface_description_invalid_interface(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g99").once().ordered().and_return([
                 "An invalid interface has been used for this function."
@@ -1552,8 +1313,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 1/g99"))
 
     def test_set_interface_description_invalid_description(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/g10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("description \"Hey \"you\"\"").once().ordered().and_return([
@@ -1568,8 +1327,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Invalid description : Hey \"you\""))
 
     def test_set_bond_description(self):
-        self.command_setup()
-
         with self.configuring_and_committing():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("description \"Hey\"").once().ordered().and_return([])
@@ -1578,8 +1335,6 @@ class DellTest(unittest.TestCase):
         self.switch.set_bond_description(10, "Hey")
 
     def test_set_bond_description_invalid_bond(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 99999").once().ordered().and_return([
                 "An invalid interface has been used for this function."
@@ -1591,8 +1346,6 @@ class DellTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("Bond 99999 not found"))
 
     def test_set_bond_description_invalid_description(self):
-        self.command_setup()
-
         with self.configuring():
             self.mocked_ssh_client.should_receive("do").with_args("interface port-channel 10").once().ordered().and_return([])
             self.mocked_ssh_client.should_receive("do").with_args("description \"Hey \"you\"\"").once().ordered().and_return([
@@ -1606,6 +1359,12 @@ class DellTest(unittest.TestCase):
 
         assert_that(str(expect.exception), equal_to("Invalid description : Hey \"you\""))
 
+    def test_commit(self):
+        self.mocked_ssh_client.should_receive("do").with_args("copy running-config startup-config", wait_for="? (y/n) ").once().ordered().and_return([])
+        self.mocked_ssh_client.should_receive("send_key").with_args("y").once().ordered().and_return([])
+
+        self.switch.commit_transaction()
+
     @contextmanager
     def configuring_and_committing(self):
         self.mocked_ssh_client.should_receive("do").with_args("configure").once().ordered().and_return([])
@@ -1613,8 +1372,6 @@ class DellTest(unittest.TestCase):
         yield
 
         self.mocked_ssh_client.should_receive("do").with_args("exit").once().ordered().and_return([])
-        self.mocked_ssh_client.should_receive("do").with_args("copy running-config startup-config", wait_for="? (y/n) ").once().ordered().and_return([])
-        self.mocked_ssh_client.should_receive("send_key").with_args("y").once().ordered().and_return([])
 
     @contextmanager
     def configuring(self):

--- a/tests/adapters/switches/juniper_qfx_copper_test.py
+++ b/tests/adapters/switches/juniper_qfx_copper_test.py
@@ -45,7 +45,7 @@ class JuniperTest(unittest.TestCase):
 
     def setUp(self):
         self.switch = Juniper(
-                switch_descriptor=SwitchDescriptor(model='juniper', hostname="toto"),
+                switch_descriptor=SwitchDescriptor(model='juniper_qfx_copper', hostname="toto"),
                 custom_strategies=JuniperQfxCopperCustomStrategies()
         )
         self.netconf_mock = flexmock()


### PR DESCRIPTION
They test methods directly instead of passing by a switch transactionnal, this makes changes to wrapping objects to change without impacting these tests