### PR TITLE
Delegate connection logic to FlowControlSwitch

### DIFF
--- a/netman/core/switch_sessions.py
+++ b/netman/core/switch_sessions.py
@@ -43,12 +43,10 @@ class SwitchSessionManager(object):
         if session_id in self.sessions:
             raise SessionAlreadyExists(session_id)
 
-        switch.connect()
         try:
             switch.start_transaction()
         except:
             self.logger.exception("Session {} caught an exception while trying to start transaction".format(session_id))
-            switch.disconnect()
             raise
 
         self.logger.info("Switch for session {} connected and in transaction mode, storing session".format(session_id))
@@ -98,7 +96,6 @@ class SwitchSessionManager(object):
         finally:
             self._remove_session(session_id)
             self._stop_timer(session_id)
-            switch.disconnect()
 
     def _cancel_session(self, session_id):
         self.logger.info("Inactivity timeout reached for session {}".format(session_id))


### PR DESCRIPTION
That way it's connected AFTER the locking in .start_transaction