### PR TITLE
Factor out the connect_timeout and command_timeout to be configurable

### DIFF
--- a/netman/adapters/shell/__init__.py
+++ b/netman/adapters/shell/__init__.py
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+default_command_timeout = 300
+default_connect_timeout = 60

--- a/netman/adapters/shell/base.py
+++ b/netman/adapters/shell/base.py
@@ -14,9 +14,6 @@
 
 
 class TerminalClient(object):
-    _default_command_timeout = 300
-    _default_connect_timeout = 60
-
     def do(self, command, wait_for=None, include_last_line=False):
         raise NotImplemented()
 
@@ -28,11 +25,3 @@ class TerminalClient(object):
 
     def get_current_prompt(self):
         raise NotImplemented()
-
-    @staticmethod
-    def set_default_command_timeout(command_timeout):
-        TerminalClient._default_command_timeout = command_timeout
-
-    @staticmethod
-    def set_default_connect_timeout(connect_timeout):
-        TerminalClient._default_connect_timeout = connect_timeout

--- a/netman/adapters/shell/base.py
+++ b/netman/adapters/shell/base.py
@@ -14,6 +14,9 @@
 
 
 class TerminalClient(object):
+    _default_command_timeout = 300
+    _default_connect_timeout = 60
+
     def do(self, command, wait_for=None, include_last_line=False):
         raise NotImplemented()
 
@@ -25,3 +28,11 @@ class TerminalClient(object):
 
     def get_current_prompt(self):
         raise NotImplemented()
+
+    @staticmethod
+    def set_default_command_timeout(command_timeout):
+        TerminalClient._default_command_timeout = command_timeout
+
+    @staticmethod
+    def set_default_connect_timeout(connect_timeout):
+        TerminalClient._default_connect_timeout = connect_timeout

--- a/netman/adapters/shell/ssh.py
+++ b/netman/adapters/shell/ssh.py
@@ -17,6 +17,7 @@ import logging
 import time
 
 import paramiko
+from netman.adapters import shell
 
 from netman.adapters.shell.base import TerminalClient
 from netman.core.objects.exceptions import CouldNotConnect, ConnectTimeout, CommandTimeout
@@ -32,8 +33,8 @@ class SshClient(TerminalClient):
         self.port = port
         self.username = username
         self.prompt = prompt
-        self.command_timeout = command_timeout or self._default_command_timeout
-        self.connect_timeout = connect_timeout or self._default_connect_timeout
+        self.command_timeout = command_timeout or shell.default_command_timeout
+        connect_timeout = connect_timeout or shell.default_connect_timeout
         self.reading_interval = reading_interval
         self.reading_chunk_size = reading_chunk_size
 
@@ -42,7 +43,7 @@ class SshClient(TerminalClient):
         self.channel = None
         self.full_log = ""
 
-        self._open_channel(host, port, username, password, self.connect_timeout)
+        self._open_channel(host, port, username, password, connect_timeout)
 
     def do(self, command, wait_for=None, include_last_line=False):
         self.logger.debug("[SSH][{}@{}:{}] Send >> {}".format(self.username, self.host, self.port, command))

--- a/netman/adapters/shell/ssh.py
+++ b/netman/adapters/shell/ssh.py
@@ -24,7 +24,7 @@ from netman.core.objects.exceptions import CouldNotConnect, ConnectTimeout, Comm
 
 class SshClient(TerminalClient):
 
-    def __init__(self, host, username, password, port=22, prompt=('>', '#'), connect_timeout=60, command_timeout=300,
+    def __init__(self, host, username, password, port=22, prompt=('>', '#'), connect_timeout=None, command_timeout=None,
                  reading_interval=0.01, reading_chunk_size=9999):
         self.logger = logging.getLogger(__name__)
 
@@ -32,7 +32,8 @@ class SshClient(TerminalClient):
         self.port = port
         self.username = username
         self.prompt = prompt
-        self.command_timeout = command_timeout
+        self.command_timeout = command_timeout or self._default_command_timeout
+        self.connect_timeout = connect_timeout or self._default_connect_timeout
         self.reading_interval = reading_interval
         self.reading_chunk_size = reading_chunk_size
 
@@ -41,7 +42,7 @@ class SshClient(TerminalClient):
         self.channel = None
         self.full_log = ""
 
-        self._open_channel(host, port, username, password, connect_timeout)
+        self._open_channel(host, port, username, password, self.connect_timeout)
 
     def do(self, command, wait_for=None, include_last_line=False):
         self.logger.debug("[SSH][{}@{}:{}] Send >> {}".format(self.username, self.host, self.port, command))

--- a/netman/adapters/shell/telnet.py
+++ b/netman/adapters/shell/telnet.py
@@ -16,6 +16,7 @@ import re
 import telnetlib
 from telnetlib import IAC, DO, DONT, WILL, WONT
 
+from netman.adapters import shell
 from netman.adapters.shell.base import TerminalClient
 from netman.core.objects.exceptions import CouldNotConnect, CommandTimeout, ConnectTimeout
 
@@ -25,11 +26,11 @@ class TelnetClient(TerminalClient):
     def __init__(self, host, username, password, port=23, prompt=('>', '#'),
                  connect_timeout=None, command_timeout=None, **_):
         self.prompt = prompt
-        self.command_timeout = command_timeout or self._default_command_timeout
-        self.connect_timeout = connect_timeout or self._default_connect_timeout
+        self.command_timeout = command_timeout or shell.default_command_timeout
+        connect_timeout = connect_timeout or shell.default_connect_timeout
         self.full_log = ""
 
-        self.telnet = _connect(host, port, self.connect_timeout)
+        self.telnet = _connect(host, port, connect_timeout)
         self._login(username, password)
 
     def do(self, command, wait_for=None, include_last_line=False):

--- a/netman/adapters/shell/telnet.py
+++ b/netman/adapters/shell/telnet.py
@@ -23,13 +23,13 @@ from netman.core.objects.exceptions import CouldNotConnect, CommandTimeout, Conn
 class TelnetClient(TerminalClient):
 
     def __init__(self, host, username, password, port=23, prompt=('>', '#'),
-                 connect_timeout=60, command_timeout=300, **_):
+                 connect_timeout=None, command_timeout=None, **_):
         self.prompt = prompt
-        self.command_timeout = command_timeout
-
+        self.command_timeout = command_timeout or self._default_command_timeout
+        self.connect_timeout = connect_timeout or self._default_connect_timeout
         self.full_log = ""
 
-        self.telnet = _connect(host, port, connect_timeout)
+        self.telnet = _connect(host, port, self.connect_timeout)
         self._login(username, password)
 
     def do(self, command, wait_for=None, include_last_line=False):

--- a/tests/adapters/shell/terminal_client_test.py
+++ b/tests/adapters/shell/terminal_client_test.py
@@ -22,6 +22,7 @@ from mock import patch, Mock
 
 from twisted.internet.protocol import Factory
 
+from netman.adapters import shell
 from netman.adapters.shell.ssh import SshClient
 from netman.adapters.shell.telnet import TelnetClient
 from netman.core.objects.exceptions import CouldNotConnect, CommandTimeout, ConnectTimeout
@@ -197,27 +198,27 @@ class SshClientTest(TerminalClientTest):
 
     @patch('netman.adapters.shell.ssh.SshClient._open_channel')
     def test_changing_default_connect_timeout(self, open_channel_method_mock):
+        shell.default_connect_timeout = 60
+
         SshClient(**self._get_some_credentials())
         self.assertEqual(60, open_channel_method_mock.call_args[0][4])
 
-        TelnetClient.set_default_connect_timeout(120)
+        shell.default_connect_timeout = 120
 
         SshClient(**self._get_some_credentials())
         self.assertEqual(120, open_channel_method_mock.call_args[0][4])
 
-        TelnetClient.set_default_connect_timeout(60)
-
     @patch('netman.adapters.shell.ssh.SshClient._open_channel', Mock())
     def test_changing_default_command_timeout(self):
+        shell.base.default_command_timeout = 300
+
         ssh = SshClient(**self._get_some_credentials())
         self.assertEqual(300, ssh.command_timeout)
 
-        TelnetClient.set_default_command_timeout(600)
+        shell.default_command_timeout = 600
 
         ssh2 = SshClient(**self._get_some_credentials())
         self.assertEqual(600, ssh2.command_timeout)
-
-        TelnetClient.set_default_command_timeout(300)
 
 
 class TelnetClientTest(TerminalClientTest):
@@ -229,28 +230,28 @@ class TelnetClientTest(TerminalClientTest):
     @patch('netman.adapters.shell.telnet._connect')
     @patch('netman.adapters.shell.telnet.TelnetClient._login', Mock())
     def test_changing_default_connect_timeout(self, connect_method_mock):
+        shell.default_connect_timeout = 60
+
         TelnetClient(**self._get_some_credentials())
         self.assertEqual(60, connect_method_mock.call_args[0][2])
 
-        TelnetClient.set_default_connect_timeout(120)
+        shell.default_connect_timeout = 120
 
         TelnetClient(**self._get_some_credentials())
         self.assertEqual(120, connect_method_mock.call_args[0][2])
 
-        TelnetClient.set_default_connect_timeout(60)
-
     @patch('netman.adapters.shell.telnet._connect', Mock())
     @patch('netman.adapters.shell.telnet.TelnetClient._login', Mock())
     def test_changing_default_command_timeout(self):
+        shell.default_command_timeout = 300
+
         telnet = TelnetClient(**self._get_some_credentials())
         self.assertEqual(300, telnet.command_timeout)
 
-        TelnetClient.set_default_command_timeout(600)
+        shell.default_command_timeout = 600
 
         telnet2 = TelnetClient(**self._get_some_credentials())
         self.assertEqual(600, telnet2.command_timeout)
-
-        TelnetClient.set_default_command_timeout(300)
 
 
 class SwitchTelnetFactory(Factory):


### PR DESCRIPTION
This will allow external library users to modify the default timeout used
in the telnet / ssh connections using the method:

    netman.adapters.shell.default_connect_timeout = 60
    netman.adapters.shell.default_command_timeout = 300

The downside is that uses a package instance so the modifications are done for a package scope (not instance scope). However, since netman has currently no adapter config mecanism, there is no easy way to do this.