### PR TITLE
Improve warnings

### DIFF
--- a/netman/core/objects/backward_compatible_switch_operations.py
+++ b/netman/core/objects/backward_compatible_switch_operations.py
@@ -21,49 +21,49 @@ class BackwardCompatibleSwitchOperations(object):
     Depecrated methods
     """
     def remove_access_vlan(self, interface_id):
-        warnings.warn("Deprecated, use unset_interface_access_vlan(interface_id) instead")
+        warnings.warn("Deprecated, use unset_interface_access_vlan(interface_id) instead", DeprecationWarning)
         return self.unset_interface_access_vlan(interface_id)
 
     def configure_native_vlan(self, interface_id, vlan):
-        warnings.warn("Deprecated, use set_interface_native_vlan(interface_id, vlan) instead")
+        warnings.warn("Deprecated, use set_interface_native_vlan(interface_id, vlan) instead", DeprecationWarning)
         return self.set_interface_native_vlan(interface_id, vlan)
 
     def remove_native_vlan(self, interface_id):
-        warnings.warn("Deprecated, use unset_interface_native_vlan(interface_id) instead")
+        warnings.warn("Deprecated, use unset_interface_native_vlan(interface_id) instead", DeprecationWarning)
         return self.unset_interface_native_vlan(interface_id)
 
     def remove_vlan_access_group(self, vlan_number, direction):
-        warnings.warn("Deprecated, use unset_vlan_access_group(vlan_number, direction) instead")
+        warnings.warn("Deprecated, use unset_vlan_access_group(vlan_number, direction) instead", DeprecationWarning)
         return self.unset_vlan_access_group(vlan_number, direction)
 
     def remove_vlan_vrf(self, vlan_number):
-        warnings.warn("Deprecated, use unset_vlan_vrf(vlan_number) instead")
+        warnings.warn("Deprecated, use unset_vlan_vrf(vlan_number) instead", DeprecationWarning)
         return self.unset_vlan_vrf(vlan_number)
 
     def remove_interface_description(self, interface_id):
-        warnings.warn("Deprecated, use unset_interface_description(interface_id) instead")
+        warnings.warn("Deprecated, use unset_interface_description(interface_id) instead", DeprecationWarning)
         return self.unset_interface_description(interface_id)
 
     def remove_bond_description(self, number):
-        warnings.warn("Deprecated, use unset_bond_description(number) instead")
+        warnings.warn("Deprecated, use unset_bond_description(number) instead", DeprecationWarning)
         return self.unset_bond_description(number)
 
     def configure_bond_native_vlan(self, number, vlan):
-        warnings.warn("Deprecated, use set_bond_native_vlan(number, vlan) instead")
+        warnings.warn("Deprecated, use set_bond_native_vlan(number, vlan) instead", DeprecationWarning)
         return self.set_bond_native_vlan(number, vlan)
 
     def remove_bond_native_vlan(self, number):
-        warnings.warn("Deprecated, use unset_bond_native_vlan(number) instead")
+        warnings.warn("Deprecated, use unset_bond_native_vlan(number) instead", DeprecationWarning)
         return self.unset_bond_native_vlan(number)
 
     def enable_lldp(self, interface_id, enabled):
-        warnings.warn("Deprecated, use set_interface_lldp_state(interface_id, enabled) instead")
+        warnings.warn("Deprecated, use set_interface_lldp_state(interface_id, enabled) instead", DeprecationWarning)
         return self.set_interface_lldp_state(interface_id, enabled)
 
     def shutdown_interface(self, interface_id):
-        warnings.warn("Deprecated, use set_interface_state(interface_id, state) instead")
+        warnings.warn("Deprecated, use set_interface_state(interface_id, state) instead", DeprecationWarning)
         return self.set_interface_state(interface_id, OFF)
 
     def openup_interface(self, interface_id):
-        warnings.warn("Deprecated, use set_interface_state(interface_id, state) instead")
+        warnings.warn("Deprecated, use set_interface_state(interface_id, state) instead", DeprecationWarning)
         return self.set_interface_state(interface_id, ON)

--- a/netman/core/objects/switch_transactional.py
+++ b/netman/core/objects/switch_transactional.py
@@ -18,7 +18,7 @@ from netman.core.objects.flow_control_switch import FlowControlSwitch
 
 
 def transactional(fn):
-    warnings.warn("Deprecated, make your own annotation this one will disappear")
+    warnings.warn("Deprecated, make your own annotation this one will disappear", DeprecationWarning)
     @wraps(fn)
     def wrapper(self, *args, **kwargs):
         if self.in_transaction:
@@ -32,7 +32,7 @@ def transactional(fn):
 
 class SwitchTransactional(FlowControlSwitch):
     def __init__(self, impl, lock):
-        warnings.warn("Deprecated, use FlowControlSwitch instead")
+        warnings.warn("Deprecated, use FlowControlSwitch instead", DeprecationWarning)
         super(SwitchTransactional, self).__init__(impl, lock)
 
     @property

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from functools import wraps
+import warnings
 
 from tests.adapters.model_list import available_models
 from netaddr import IPNetwork
@@ -44,3 +46,13 @@ class ExactIpNetwork(object):
 
     def __repr__(self):
         return "{}/{}".format(self.ip, self.mask)
+
+
+def ignore_deprecation_warning(func):
+    @wraps(func)
+    def func_wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            ret = func(*args, **kwargs)
+            return ret
+    return func_wrapper

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -48,7 +48,7 @@ class ExactIpNetwork(object):
         return "{}/{}".format(self.ip, self.mask)
 
 
-def ignore_deprecation_warning(func):
+def ignore_deprecation_warnings(func):
     @wraps(func)
     def func_wrapper(*args, **kwargs):
         with warnings.catch_warnings():

--- a/tests/adapters/switches/remote_test.py
+++ b/tests/adapters/switches/remote_test.py
@@ -22,7 +22,7 @@ from netaddr import IPAddress
 from flexmock import flexmock, flexmock_teardown
 
 from netman.core.objects.interface_states import OFF, ON
-from tests import ExactIpNetwork
+from tests import ExactIpNetwork, ignore_deprecation_warnings
 from tests.api import open_fixture
 from netman.adapters.switches.remote import RemoteSwitch, factory
 from netman.core.objects.access_groups import IN, OUT
@@ -436,6 +436,7 @@ class RemoteSwitchTest(unittest.TestCase):
         assert_that(if4.shutdown, equal_to(False))
         assert_that(if4.bond_master, equal_to(12))
 
+    @ignore_deprecation_warnings
     def test_get_bond_v1(self):
         self.requests_mock.should_receive("get").once().with_args(
             url=self.netman_url+'/switches/toto/bonds/3',

--- a/tests/core/objects/backward_compatible_switch_operations_test.py
+++ b/tests/core/objects/backward_compatible_switch_operations_test.py
@@ -12,85 +12,84 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from unittest import TestCase
-
 from flexmock import flexmock
-from mock import patch, Mock
 
 from netman.core.objects.access_groups import IN
 from netman.core.objects.interface_states import OFF, ON
 from netman.core.objects.switch_base import SwitchOperations
+from tests import ignore_deprecation_warnings
 
 
 class BackwardCompatibleSwitchOperationsTest(TestCase):
     def setUp(self):
         self.switch = flexmock(SwitchOperations())
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+
+    @ignore_deprecation_warnings
     def test_remove_access_vlan_call_unset_interface_access_vlan(self):
         self.switch.should_receive("unset_interface_access_vlan").with_args(1000).once()
-
         self.switch.remove_access_vlan(1000)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_configure_native_vlan_call_set_interface_native_vlan(self):
         self.switch.should_receive("set_interface_native_vlan").with_args("ethernet 1/g10", 1000).once()
 
         self.switch.configure_native_vlan("ethernet 1/g10", 1000)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_remove_native_vlan_call_unset_interface_native_vlan(self):
         self.switch.should_receive("unset_interface_native_vlan").with_args(1000).once()
 
         self.switch.remove_native_vlan(1000)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_remove_vlan_access_group_call_unset_vlan_access_group(self):
         self.switch.should_receive("unset_vlan_access_group").with_args(1000, IN).once()
 
         self.switch.remove_vlan_access_group(1000, IN)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_remove_vlan_vrf_call_unset_vlan_vrf(self):
         self.switch.should_receive("unset_vlan_vrf").with_args(1000).once()
 
         self.switch.remove_vlan_vrf(1000)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_remove_interface_description_call_unset_interface_description(self):
         self.switch.should_receive("unset_interface_description").with_args("ethernet 1/g10").once()
 
         self.switch.remove_interface_description("ethernet 1/g10")
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_remove_bond_description_call_unset_bond_description(self):
         self.switch.should_receive("unset_bond_description").with_args(295).once()
 
         self.switch.remove_bond_description(295)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_configure_bond_native_vlan_call_set_bond_native_vlan(self):
         self.switch.should_receive("set_bond_native_vlan").with_args(295, 1000).once()
 
         self.switch.configure_bond_native_vlan(295, 1000)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_remove_bond_native_vlan_call_unset_bond_native_vlan(self):
         self.switch.should_receive("unset_bond_native_vlan").with_args(295).once()
 
         self.switch.remove_bond_native_vlan(295)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_enable_lldp_call_set_interface_lldp_state(self):
         self.switch.should_receive("set_interface_lldp_state").with_args("ethernet 1/g10", True).once()
 
         self.switch.enable_lldp("ethernet 1/g10", True)
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_shutdown_interface_call_set_interface_state(self):
         self.switch.should_receive("set_interface_state").with_args("ethernet 1/g10", OFF).once()
 
         self.switch.shutdown_interface("ethernet 1/g10")
 
-    @patch("netman.core.objects.backward_compatible_switch_operations.warnings.warn", Mock())
+    @ignore_deprecation_warnings
     def test_openup_interface_call_set_interface_state(self):
         self.switch.should_receive("set_interface_state").with_args("ethernet 1/g10", ON).once()
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist = py27
 
 [testenv]
+setenv = 
+    PYTHONWARNINGS = default
 deps = -r{toxinidir}/test-requirements.txt
 commands =
     nosetests --tests tests


### PR DESCRIPTION
This improve the way netman's handle deprecation in the following ways:

* Deprecation and import warning are shown by default
* Now deprecated function Warns with DeprecationWarnings instead of normal warnings.
* Function that test deprecated feature has @ignore_deprecation_warnings decorator that hide those warnings insead of mocking the module's warnings object.

It also allows intellij to see which function are ~~deprecated~~ :

![striketrough text](http://i.imgur.com/26OUoI6.png) 