### PR TITLE
Add interfaces on getvlans

### DIFF
--- a/netman/adapters/switches/brocade.py
+++ b/netman/adapters/switches/brocade.py
@@ -439,10 +439,12 @@ def parse_vlan(vlan_data):
     for line in vlan_data[1:]:
         if regex.match("^\srouter-interface ve (\d+)", line):
             current_vlan.vlan_interface_name = regex[0]
-        elif regex.match(" tagged (.*)", line):
-            for name in parse_if_ranges(regex[0]):
-                current_vlan.tagged_interfaces.append(name)
-
+        elif regex.match("^\s(tagged|no untagged)\s(.*)$", line):
+            type = regex[0]
+            for name in parse_if_ranges(regex[1]):
+                current_vlan.interfaces.append(name)
+                if type == "tagged":
+                    current_vlan.tagged_interfaces.append(name)
     return current_vlan
 
 

--- a/netman/core/objects/vlan.py
+++ b/netman/core/objects/vlan.py
@@ -18,7 +18,7 @@ from netman.core.objects.access_groups import OUT, IN
 
 class Vlan(Model):
     def __init__(self, number=None, name=None, ips=None, vrrp_groups=None, vrf_forwarding=None, access_group_in=None,
-                 access_group_out=None, dhcp_relay_servers=None, icmp_redirects=None):
+                 access_group_out=None, dhcp_relay_servers=None, icmp_redirects=None, interfaces = None):
         self.number = number
         self.name = name
         self.access_groups = {IN: access_group_in, OUT: access_group_out}
@@ -27,3 +27,4 @@ class Vlan(Model):
         self.vrrp_groups = vrrp_groups or []
         self.dhcp_relay_servers = dhcp_relay_servers or []
         self.icmp_redirects = icmp_redirects
+        self.interfaces = interfaces or []

--- a/tests/adapters/switches/brocade_test.py
+++ b/tests/adapters/switches/brocade_test.py
@@ -207,6 +207,16 @@ class BrocadeTest(unittest.TestCase):
         assert_that(str(vlan201.dhcp_relay_servers[0]), equal_to('10.10.10.1'))
         assert_that(str(vlan201.dhcp_relay_servers[1]), equal_to('10.10.10.2'))
 
+        assert_that(vlan1.tagged_interfaces, equal_to([]))
+        assert_that(vlan201.tagged_interfaces, equal_to(["ethe 1/1"]))
+        assert_that(vlan2222.tagged_interfaces, equal_to(["ethe 1/1"]))
+        assert_that(vlan3333.tagged_interfaces, equal_to([]))
+
+        assert_that(vlan1.interfaces, equal_to(["ethe 1/1", "ethe 1/20", "ethe 1/21", "ethe 1/22"]))
+        assert_that(vlan201.interfaces, equal_to(["ethe 1/1"]))
+        assert_that(vlan2222.interfaces, equal_to(["ethe 1/1"]))
+        assert_that(vlan3333.interfaces, equal_to([]))
+
     def test_get_vlan_with_no_interface(self):
         self.shell_mock.should_receive("do").with_args("show vlan 1750").once().ordered().and_return(
             vlan_display(1750)


### PR DESCRIPTION
This prevent do a second call to get_interface (sometime long) when you want to know which interface is associated with a vlan.

This PR only addresses brocade, juniper,cisco and dell PRs will follow