### PR TITLE
Add interfaces on getvlans

### DIFF
--- a/netman/core/objects/vlan.py
+++ b/netman/core/objects/vlan.py
@@ -18,7 +18,7 @@ from netman.core.objects.access_groups import OUT, IN
 
 class Vlan(Model):
     def __init__(self, number=None, name=None, ips=None, vrrp_groups=None, vrf_forwarding=None, access_group_in=None,
-                 access_group_out=None, dhcp_relay_servers=None, icmp_redirects=None):
+                 access_group_out=None, dhcp_relay_servers=None, icmp_redirects=None, interfaces=None):
         self.number = number
         self.name = name
         self.access_groups = {IN: access_group_in, OUT: access_group_out}
@@ -27,3 +27,4 @@ class Vlan(Model):
         self.vrrp_groups = vrrp_groups or []
         self.dhcp_relay_servers = dhcp_relay_servers or []
         self.icmp_redirects = icmp_redirects
+        self.interfaces = interfaces or []

--- a/tests/adapters/switches/brocade_test.py
+++ b/tests/adapters/switches/brocade_test.py
@@ -110,6 +110,7 @@ class BrocadeTest(unittest.TestCase):
     def test_get_vlans(self):
         self.shell_mock.should_receive("do").with_args("show running-config vlan | begin vlan").once().ordered().and_return([
             "vlan 1 name DEFAULT-VLAN",
+            ""
             " no untagged ethe 1/1 ethe 1/3 to 1/22",
             "!",
             "vlan 201",
@@ -118,6 +119,7 @@ class BrocadeTest(unittest.TestCase):
             "!",
             "vlan 2222 name your-name-is-way-too-long-for-t",
             " tagged ethe 1/1",
+            " untagged ethe 1/2",
             "!",
             "vlan 3333 name some-name",
             "!",
@@ -168,7 +170,8 @@ class BrocadeTest(unittest.TestCase):
         ])
 
         self.shell_mock.should_receive("do").with_args("show vlan 1").once().ordered().and_return(
-            VlanDisplayBuilder(1, 'DEFAULT-VLAN').with_tagged_ports("ethe 1/2 ethe 1/23 to 1/24").to_strings()
+            VlanDisplayBuilder(1, 'DEFAULT-VLAN').with_tagged_ports("ethe 1/2 ethe 1/23 to 1/24")
+                                                 .to_strings()
         )
 
         vlan1, vlan201, vlan2222, vlan3333 = self.switch.get_vlans()
@@ -213,7 +216,7 @@ class BrocadeTest(unittest.TestCase):
 
         assert_that(vlan1.interfaces, equal_to(["ethernet 1/2", "ethernet 1/23", "ethernet 1/24"]))
         assert_that(vlan201.interfaces, equal_to(["ethernet 1/1"]))
-        assert_that(vlan2222.interfaces, equal_to(["ethernet 1/1"]))
+        assert_that(vlan2222.interfaces, equal_to(["ethernet 1/1", "ethernet 1/2"]))
         assert_that(vlan3333.interfaces, equal_to([]))
 
     def test_get_vlan_with_no_interface(self):

--- a/tests/adapters/switches/brocade_test.py
+++ b/tests/adapters/switches/brocade_test.py
@@ -126,6 +126,10 @@ class BrocadeTest(unittest.TestCase):
             "!"
         ])
 
+        self.shell_mock.should_receive("do").with_args("show vlan 1").once().ordered().and_return(
+                vlan_display(1, 'DEFAULT-VLAN', tagged_port_str="ethe 1/2 ethe 1/23 to 1/24")
+        )
+
         self.shell_mock.should_receive("do").with_args("show running-config interface").once()\
             .ordered().and_return([
                 'interface ve 428',
@@ -169,9 +173,6 @@ class BrocadeTest(unittest.TestCase):
                 '!'
         ])
 
-        self.shell_mock.should_receive("do").with_args("show vlan 1").once().ordered().and_return(
-            vlan_display(1, 'DEFAULT-VLAN', tagged_port_str="ethe 1/2 ethe 1/23 to 1/24")
-        )
 
         vlan1, vlan201, vlan2222, vlan3333 = self.switch.get_vlans()
 

--- a/tests/adapters/switches/brocade_test.py
+++ b/tests/adapters/switches/brocade_test.py
@@ -2146,38 +2146,61 @@ class BrocadeTest(unittest.TestCase):
 
 
 def vlan_display(vlan_id, name="[None]"):
-    return [
-        "PORT-VLAN {}, Name {}, Priority Level -, Priority Force 0, Creation Type STATIC".format(vlan_id, name),
-        "Topo HW idx    : 81    Topo SW idx: 257    Topo next vlan: 0",
-        "L2 protocols   : STP",
-        "Associated Virtual Interface Id: NONE",
-        "----------------------------------------------------------",
-        "No ports associated with VLAN",
-        "Arp Inspection: 0",
-        "DHCP Snooping: 0",
-        "IPv4 Multicast Snooping: Disabled",
-        "IPv6 Multicast Snooping: Disabled",
-        "No Virtual Interfaces configured for this vlan"
-    ]
+    return VlanDisplayBuilder(vlan_id, name).to_strings()
 
 
 def vlan_with_vif_display(vlan_id, vif_id, name="[None]"):
-    return [
-        "PORT-VLAN {}, Name {}, Priority Level -, Priority Force 0, Creation Type STATIC".format(vlan_id, name),
-        "Topo HW idx    : 81    Topo SW idx: 257    Topo next vlan: 0",
-        "L2 protocols   : STP",
-        "Associated Virtual Interface Id: {}".format(vif_id),
-        "----------------------------------------------------------",
-        "No ports associated with VLAN",
-        "Arp Inspection: 0",
-        "DHCP Snooping: 0",
-        "IPv4 Multicast Snooping: Disabled",
-        "IPv6 Multicast Snooping: Disabled",
-        "Ve{} is down, line protocol is down".format(vif_id),
-        "  Type is Vlan (Vlan Id: {})".format(vlan_id),
-        "  Hardware is Virtual Ethernet, address is 748e.f8a7.1b01 (bia 748e.f8a7.1b01)",
-        "  No port name",
-        "  Vlan id: {}".format(vlan_id),
-        "  Internet address is 0.0.0.0/0, IP MTU 1500 bytes, encapsulation ethernet",
-        "  Configured BW 0 kbps",
-    ]
+    return VlanDisplayBuilder(vlan_id, name).with_vif_display(vif_id).to_strings()
+
+class VlanDisplayBuilder:
+    def __init__(self, vlan_id=9, vlan_name=""):
+        self.vlan_id = vlan_id
+        self.vlan_name = vlan_name
+        self.port_info = []
+        self.vif_id = None
+
+    def with_tagged_ports(self, ports=""):
+        return self.with_ports('Statically tagged Ports', ports)
+
+    def with_untagged_port(self, ports=""):
+        return self.with_ports('Untagged Ports', ports)
+
+    def with_ports(self, port_type="", ports=""):
+        self.port_info.append(
+            "{} : {}".format(port_type, ports)
+        )
+        return self
+
+    def with_vif_display(self, vif_id=None):
+        self.vif_id = vif_id
+        return self
+
+    def to_strings(self):
+        ret = [
+            "PORT-VLAN {}, Name {}, Priority Level -, Priority Force 0, Creation Type STATIC".format(self.vlan_id, self.vlan_name),
+            "Topo HW idx    : 81    Topo SW idx: 257    Topo next vlan: 0",
+            "L2 protocols   : STP",
+            ]
+        ret.extend(self.port_info)
+        ret.extend([
+            "Associated Virtual Interface Id: {}".format(self.vif_id or "NONE"),
+            "----------------------------------------------------------",
+            "No ports associated with VLAN",
+            "Arp Inspection: 0",
+            "DHCP Snooping: 0",
+            "IPv4 Multicast Snooping: Disabled",
+            "IPv6 Multicast Snooping: Disabled",
+        ])
+        if self.vif_id:
+            ret.extend([
+                "Ve{} is down, line protocol is down".format(self.vif_id),
+                "  Type is Vlan (Vlan Id: {})".format(self.vlan_id),
+                "  Hardware is Virtual Ethernet, address is 748e.f8a7.1b01 (bia 748e.f8a7.1b01)",
+                "  No port name",
+                "  Vlan id: {}".format(self.vlan_id),
+                "  Internet address is 0.0.0.0/0, IP MTU 1500 bytes, encapsulation ethernet",
+                "  Configured BW 0 kbps",
+            ])
+        else:
+            ret.append("No Virtual Interfaces configured for this vlan")
+        return ret

--- a/tests/adapters/switches/brocade_test.py
+++ b/tests/adapters/switches/brocade_test.py
@@ -170,8 +170,7 @@ class BrocadeTest(unittest.TestCase):
         ])
 
         self.shell_mock.should_receive("do").with_args("show vlan 1").once().ordered().and_return(
-            VlanDisplayBuilder(1, 'DEFAULT-VLAN').with_tagged_ports("ethe 1/2 ethe 1/23 to 1/24")
-                                                 .to_strings()
+            vlan_display(1, 'DEFAULT-VLAN', tagged_port_str="ethe 1/2 ethe 1/23 to 1/24")
         )
 
         vlan1, vlan201, vlan2222, vlan3333 = self.switch.get_vlans()
@@ -258,9 +257,8 @@ class BrocadeTest(unittest.TestCase):
 
     def test_get_vlan_ports(self):
         self.shell_mock.should_receive("do").with_args("show vlan 1").once().ordered().and_return(
-            VlanDisplayBuilder(1, "DEFAULT-VLAN").with_untagged_port('ethe 1/2 ethe 1/23 to 1/24')
-                .with_tagged_ports("ethe 1/4")
-                .to_strings()
+            vlan_display(1, "DEFAULT-VLAN", untagged_port_str='ethe 1/2 ethe 1/23 to 1/24',
+                         tagged_port_str="ethe 1/4")
         )
 
         vlan = self.switch.get_vlan(1)
@@ -2168,62 +2166,39 @@ class BrocadeTest(unittest.TestCase):
         assert_that(str(expect.exception), equal_to("DHCP relay server 10.10.10.1 not found on VLAN 1234"))
 
 
-def vlan_display(vlan_id, name="[None]"):
-    return VlanDisplayBuilder(vlan_id, name).to_strings()
-
-
 def vlan_with_vif_display(vlan_id, vif_id, name="[None]"):
-    return VlanDisplayBuilder(vlan_id, name).with_vif_display(vif_id).to_strings()
+    return vlan_display(vlan_id, name, vif_id=vif_id)
 
-class VlanDisplayBuilder:
-    def __init__(self, vlan_id=9, vlan_name=""):
-        self.vlan_id = vlan_id
-        self.vlan_name = vlan_name
-        self.port_info = []
-        self.vif_id = None
 
-    def with_tagged_ports(self, ports=""):
-        return self.with_ports('Statically tagged Ports', ports)
-
-    def with_untagged_port(self, ports=""):
-        return self.with_ports('Untagged Ports', ports)
-
-    def with_ports(self, port_type="", ports=""):
-        self.port_info.append(
-            "{} : {}".format(port_type, ports)
-        )
-        return self
-
-    def with_vif_display(self, vif_id=None):
-        self.vif_id = vif_id
-        return self
-
-    def to_strings(self):
-        ret = [
-            "PORT-VLAN {}, Name {}, Priority Level -, Priority Force 0, Creation Type STATIC".format(self.vlan_id, self.vlan_name),
-            "Topo HW idx    : 81    Topo SW idx: 257    Topo next vlan: 0",
-            "L2 protocols   : STP",
-            ]
-        ret.extend(self.port_info)
+def vlan_display(vlan_id=9, vlan_name="[None]", tagged_port_str=None, untagged_port_str=None, vif_id=None):
+    ret = [
+        "PORT-VLAN {}, Name {}, Priority Level -, Priority Force 0, Creation Type STATIC".format(vlan_id, vlan_name),
+        "Topo HW idx    : 81    Topo SW idx: 257    Topo next vlan: 0",
+        "L2 protocols   : STP",
+    ]
+    if untagged_port_str:
+        ret.append("Untagged Ports : {}".format(untagged_port_str))
+    if tagged_port_str:
+        ret.append("Statically tagged Ports : {}".format(tagged_port_str))
+    ret.extend([
+        "Associated Virtual Interface Id: {}".format(vif_id or "NONE"),
+        "----------------------------------------------------------",
+        "No ports associated with VLAN",
+        "Arp Inspection: 0",
+        "DHCP Snooping: 0",
+        "IPv4 Multicast Snooping: Disabled",
+        "IPv6 Multicast Snooping: Disabled",
+    ])
+    if vif_id:
         ret.extend([
-            "Associated Virtual Interface Id: {}".format(self.vif_id or "NONE"),
-            "----------------------------------------------------------",
-            "No ports associated with VLAN",
-            "Arp Inspection: 0",
-            "DHCP Snooping: 0",
-            "IPv4 Multicast Snooping: Disabled",
-            "IPv6 Multicast Snooping: Disabled",
+            "Ve{} is down, line protocol is down".format(vif_id),
+            "  Type is Vlan (Vlan Id: {})".format(vlan_id),
+            "  Hardware is Virtual Ethernet, address is 748e.f8a7.1b01 (bia 748e.f8a7.1b01)",
+            "  No port name",
+            "  Vlan id: {}".format(vlan_id),
+            "  Internet address is 0.0.0.0/0, IP MTU 1500 bytes, encapsulation ethernet",
+            "  Configured BW 0 kbps",
         ])
-        if self.vif_id:
-            ret.extend([
-                "Ve{} is down, line protocol is down".format(self.vif_id),
-                "  Type is Vlan (Vlan Id: {})".format(self.vlan_id),
-                "  Hardware is Virtual Ethernet, address is 748e.f8a7.1b01 (bia 748e.f8a7.1b01)",
-                "  No port name",
-                "  Vlan id: {}".format(self.vlan_id),
-                "  Internet address is 0.0.0.0/0, IP MTU 1500 bytes, encapsulation ethernet",
-                "  Configured BW 0 kbps",
-            ])
-        else:
-            ret.append("No Virtual Interfaces configured for this vlan")
-        return ret
+    else:
+        ret.append("No Virtual Interfaces configured for this vlan")
+    return ret


### PR DESCRIPTION
This prevent do a second call to get_interface (sometime long) when you want to know which interface is associated with a vlan.

This PR only addresses brocade, juniper,cisco and dell PRs will follow.
