### PR TITLE
Remote Switch is now wrapped in Flow Control Switch and has separate transaction and session logic

### DIFF
--- a/netman/api/switch_session_api.py
+++ b/netman/api/switch_session_api.py
@@ -98,7 +98,11 @@ class SwitchSessionApi(SwitchApiBase):
         """
 
         action = request.data.lower()
-        if action == 'commit':
+        if action == 'start_transaction':
+            self.sessions_manager.start_transaction(session_id)
+        elif action == 'end_transaction':
+            self.sessions_manager.end_transaction(session_id)
+        elif action == 'commit':
             self.sessions_manager.commit_session(session_id)
         elif action == 'rollback':
             self.sessions_manager.rollback_session(session_id)

--- a/netman/core/switch_factory.py
+++ b/netman/core/switch_factory.py
@@ -32,6 +32,7 @@ factories = {
     "dell10g_telnet": dell10g.telnet,
 }
 
+
 class SwitchFactory(object):
 
     def __init__(self, switch_source, lock_factory):
@@ -48,7 +49,7 @@ class SwitchFactory(object):
 
     def get_switch_by_descriptor(self, switch_descriptor):
         if switch_descriptor.netman_server:
-            return RemoteSwitch(switch_descriptor)
+            return FlowControlSwitch(RemoteSwitch(switch_descriptor), lock=self.get_lock(switch_descriptor))
         return FlowControlSwitch(factories[switch_descriptor.model](switch_descriptor),
                                  lock=self.get_lock(switch_descriptor))
 

--- a/netman/core/switch_sessions.py
+++ b/netman/core/switch_sessions.py
@@ -37,17 +37,31 @@ class SwitchSessionManager(object):
         except KeyError:
             raise UnknownSession(session_id)
 
-    def open_session(self, switch, session_id):
-        self.logger.info("Creating session {}".format(session_id))
-
-        if session_id in self.sessions:
-            raise SessionAlreadyExists(session_id)
-
+    def start_transaction(self, session_id):
+        self.logger.info("Starting Transaction for session {}".format(session_id))
+        self.keep_alive(session_id)
+        switch = self.get_switch_for_session(session_id)
         try:
             switch.start_transaction()
         except:
             self.logger.exception("Session {} caught an exception while trying to start transaction".format(session_id))
             raise
+
+    def end_transaction(self, session_id):
+        self.logger.info("Ending Transaction for session {}".format(session_id))
+        self.keep_alive(session_id)
+        switch = self.get_switch_for_session(session_id)
+        try:
+            switch.end_transaction()
+        except:
+            self.logger.exception("Session {} caught an exception while trying to end transaction".format(session_id))
+            raise
+
+    def open_session(self, switch, session_id):
+        self.logger.info("Creating session {}".format(session_id))
+
+        if session_id in self.sessions:
+            raise SessionAlreadyExists(session_id)
 
         self.logger.info("Switch for session {} connected and in transaction mode, storing session".format(session_id))
         self._add_session(session_id, switch)
@@ -90,19 +104,12 @@ class SwitchSessionManager(object):
 
     def close_session(self, session_id):
         self.logger.info("Closing session {}".format(session_id))
-        switch = self.get_switch_for_session(session_id)
-        try:
-            switch.end_transaction()
-        finally:
-            self._remove_session(session_id)
-            self._stop_timer(session_id)
+        self._remove_session(session_id)
+        self._stop_timer(session_id)
 
     def _cancel_session(self, session_id):
         self.logger.info("Inactivity timeout reached for session {}".format(session_id))
-        try:
-            self.rollback_session(session_id)
-        finally:
-            self.close_session(session_id)
+        self.close_session(session_id)
 
     def _start_timer(self, session_id):
         self.logger.info("Starting inactivity timer for session {}".format(session_id))

--- a/tests/adapters/switches/remote_test.py
+++ b/tests/adapters/switches/remote_test.py
@@ -85,7 +85,36 @@ class RemoteSwitchTest(unittest.TestCase):
             Reply(
                 content=json.dumps({'session_id': '0123456789'}),
                 status_code=201))
-
+        self.requests_mock.should_receive("post").once().with_args(
+            url=self.netman_url+'/switches-sessions/0123456789/actions',
+            data='start_transaction',
+            headers={'Netman-Verbose-Errors': "yes",
+                     'Netman-Max-Version': 2,
+                     'Netman-Session-Id': '0123456789'}
+        ).and_return(
+            Reply(
+                content="",
+                status_code=204))
+        self.requests_mock.should_receive("post").once().with_args(
+            url=self.netman_url+'/switches-sessions/0123456789/actions',
+            data='commit',
+            headers={'Netman-Verbose-Errors': "yes",
+                     'Netman-Max-Version': 2,
+                     'Netman-Session-Id': '0123456789'}
+        ).and_return(
+            Reply(
+                content="",
+                status_code=204))
+        self.requests_mock.should_receive("post").once().with_args(
+            url=self.netman_url+'/switches-sessions/0123456789/actions',
+            data='end_transaction',
+            headers={'Netman-Verbose-Errors': "yes",
+                     'Netman-Max-Version': 2,
+                     'Netman-Session-Id': '0123456789'}
+        ).and_return(
+            Reply(
+                content="",
+                status_code=204))
         self.requests_mock.should_receive("delete").once().with_args(
             url=self.netman_url+'/switches-sessions/0123456789',
             headers={'Netman-Verbose-Errors': "yes",
@@ -96,13 +125,16 @@ class RemoteSwitchTest(unittest.TestCase):
                 content="",
                 status_code=204))
 
+        self.switch.connect()
         self.switch.start_transaction()
+        self.switch.commit_transaction()
         self.switch.end_transaction()
+        self.switch.disconnect()
         self.setUp()
         self.test_add_bond()
 
     @mock.patch('uuid.uuid4')
-    def test_start_transaction_fails_to_obtain_a_session(self, m_uuid):
+    def test_connect_fails_to_obtain_a_session(self, m_uuid):
         m_uuid.return_value = '0123456789'
         self.headers['Netman-Session-Id'] = '0123456789'
         self.requests_mock.should_receive("post").once().with_args(
@@ -119,10 +151,10 @@ class RemoteSwitchTest(unittest.TestCase):
                 status_code=500))
 
         with self.assertRaises(AnException):
-            self.switch.start_transaction()
+            self.switch.connect()
 
     @mock.patch('uuid.uuid4')
-    def test_end_session_fails_returns_to_normal_behavior(self, m_uuid):
+    def test_disconnect_fails_to_return_to_normal_behavior(self, m_uuid):
         m_uuid.return_value = '0123456789'
         self.headers['Netman-Session-Id'] = '0123456789'
         self.requests_mock.should_receive("post").once().with_args(
@@ -148,14 +180,14 @@ class RemoteSwitchTest(unittest.TestCase):
                 }),
                 status_code=500))
 
-        self.switch.start_transaction()
+        self.switch.connect()
         with self.assertRaises(AnException):
-            self.switch.end_transaction()
+            self.switch.disconnect()
         self.setUp()
         self.test_add_bond()
 
     @mock.patch('uuid.uuid4')
-    def test_session_is_used_when_we_are_in_a_transaction(self, m_uuid):
+    def test_session_is_used_when_we_are_in_a_session(self, m_uuid):
         m_uuid.return_value = '0123456789'
         self.headers['Netman-Session-Id'] = '0123456789'
         self.requests_mock.should_receive("post").once().with_args(
@@ -176,11 +208,11 @@ class RemoteSwitchTest(unittest.TestCase):
                 content='',
                 status_code=201))
 
-        self.switch.start_transaction()
+        self.switch.connect()
         self.switch.add_bond(6)
 
     @mock.patch('uuid.uuid4')
-    def test_commit_transaction(self, m_uuid):
+    def test_commit_transaction_fails_to_commit(self, m_uuid):
         m_uuid.return_value = '0123456789'
 
         self.headers['Netman-Session-Id'] = '0123456789'
@@ -208,12 +240,12 @@ class RemoteSwitchTest(unittest.TestCase):
                 }),
                 status_code=500))
 
-        self.switch.start_transaction()
+        self.switch.connect()
         with self.assertRaises(AnException):
             self.switch.commit_transaction()
 
     @mock.patch('uuid.uuid4')
-    def test_rollback_transaction(self, m_uuid):
+    def test_rollback_transaction_fails_to_rollback(self, m_uuid):
         m_uuid.return_value = '0123456789'
         self.headers['Netman-Session-Id'] = '0123456789'
         self.requests_mock.should_receive("post").once().ordered().with_args(
@@ -240,7 +272,7 @@ class RemoteSwitchTest(unittest.TestCase):
                 }),
                 status_code=500))
 
-        self.switch.start_transaction()
+        self.switch.connect()
         with self.assertRaises(AnException):
             self.switch.rollback_transaction()
 
@@ -282,8 +314,8 @@ class RemoteSwitchTest(unittest.TestCase):
                 content="",
                 status_code=204))
 
-        self.switch.start_transaction()
-        self.switch.end_transaction()
+        self.switch.connect()
+        self.switch.disconnect()
         self.setUp()
         self.test_add_bond()
 
@@ -325,8 +357,8 @@ class RemoteSwitchTest(unittest.TestCase):
                 content="",
                 status_code=204))
 
-        self.switch.start_transaction()
-        self.switch.end_transaction()
+        self.switch.connect()
+        self.switch.disconnect()
         self.setUp()
         self.test_add_bond()
 

--- a/tests/api/switch_api_test.py
+++ b/tests/api/switch_api_test.py
@@ -1340,6 +1340,22 @@ class SwitchApiTest(BaseApiTest):
         result, code = self.post("/switches-sessions/{}/actions".format(session_uuid), raw_data="rollback")
         assert_that(code, equal_to(204), str(result))
 
+    def test_session_start_transaction(self):
+        session_uuid = 'poisson'
+
+        self.session_manager.should_receive("get_switch_for_session").with_args(session_uuid).and_return(self.switch_mock)
+        self.session_manager.should_receive('start_transaction').with_args(session_uuid).once().ordered()
+        result, code = self.post("/switches-sessions/{}/actions".format(session_uuid), raw_data="start_transaction")
+        assert_that(code, equal_to(204), str(result))
+
+    def test_session_end_transaction(self):
+        session_uuid = 'poisson'
+
+        self.session_manager.should_receive("get_switch_for_session").with_args(session_uuid).and_return(self.switch_mock)
+        self.session_manager.should_receive('end_transaction').with_args(session_uuid).once().ordered()
+        result, code = self.post("/switches-sessions/{}/actions".format(session_uuid), raw_data="end_transaction")
+        assert_that(code, equal_to(204), str(result))
+
     def test_unknown_session(self):
         session_uuid = 'patate'
         result, code = self.post("/switches-sessions/{}/vlans".format(session_uuid), data={"number": 2000})


### PR DESCRIPTION
This logic is necessary based on how we are handling the communication with the worker servers when sending calls to the switch. So, our process of communicating with a switch can be seen like this: 

1. get a lock
2. connect (open session) to a switch
3. start transaction on the switch
4. perform switch actions (e.g. add_vlan)
5. commit on the switch
6. end transaction
7. disconnection (close session) on a switch
8 release lock

Based on this flow, it is necessary for us to remove the start and end transaction from all session logic.
