### PR TITLE
Add get_vlan_interfaces method on juniper switches.

### DIFF
--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -465,6 +465,157 @@ class JuniperTest(unittest.TestCase):
 
         assert_that(vlan1000.interfaces, equal_to([]))
 
+    def test_get_vlan_interfaces(self):
+        self.switch.in_transaction = False
+        self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
+                    <filter>
+                      <configuration>
+                        <vlans>
+                          <vlan>
+                            <vlan-id>705</vlan-id>
+                          </vlan>
+                        </vlans>
+                        <interfaces />
+                      </configuration>
+                    </filter>
+                """)).and_return(a_configuration("""
+                    <vlans>
+                      <vlan>
+                        <name>VLAN705</name>
+                        <vlan-id>705</vlan-id>
+                      </vlan>
+                    </vlans>
+                    <interfaces>
+                        <interface>
+                          <name>xe-0/0/6</name>
+                          <unit>
+                            <family>
+                              <ethernet-switching>
+                                <vlan>
+                                  <members>687</members>
+                                  <members>705</members>
+                                  <members>708</members>
+                                </vlan>
+                              </ethernet-switching>
+                            </family>
+                          </unit>
+                        </interface>
+                        <interface>
+                          <name>xe-0/0/7</name>
+                          <unit>
+                            <family>
+                              <ethernet-switching>
+                                <vlan>
+                                  <members>705</members>
+                                </vlan>
+                              </ethernet-switching>
+                            </family>
+                          </unit>
+                        </interface>
+                        <interface>
+                          <name>xe-0/0/8</name>
+                          <unit>
+                            <family>
+                              <ethernet-switching>
+                                <vlan>
+                                  <members>456</members>
+                                </vlan>
+                              </ethernet-switching>
+                            </family>
+                          </unit>
+                        </interface>
+                        <interface>
+                          <name>xe-0/0/9</name>
+                          <unit>
+                            <family>
+                              <ethernet-switching>
+                                <vlan>
+                                  <members>700-800</members>
+                                </vlan>
+                              </ethernet-switching>
+                            </family>
+                          </unit>
+                        </interface>
+                    </interfaces>
+                """))
+
+        vlan_interfaces = self.switch.get_vlan_interfaces(705)
+
+        assert_that(vlan_interfaces, equal_to(["xe-0/0/6", "xe-0/0/7", "xe-0/0/9"]))
+
+    def test_get_vlan_interfaces_with_name_as_member(self):
+        self.switch.in_transaction = False
+        self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
+                        <filter>
+                          <configuration>
+                            <vlans>
+                              <vlan>
+                                <vlan-id>705</vlan-id>
+                              </vlan>
+                            </vlans>
+                            <interfaces />
+                          </configuration>
+                        </filter>
+                    """)).and_return(a_configuration("""
+                        <vlans>
+                          <vlan>
+                            <name>bleu</name>
+                            <vlan-id>705</vlan-id>
+                          </vlan>
+                        </vlans>
+                        <interfaces>
+                            <interface>
+                              <name>xe-0/0/9</name>
+                              <unit>
+                                <family>
+                                  <ethernet-switching>
+                                    <vlan>
+                                      <members>bleu</members>
+                                    </vlan>
+                                  </ethernet-switching>
+                                </family>
+                              </unit>
+                            </interface>
+                        </interfaces>
+                    """))
+
+        vlan_interfaces = self.switch.get_vlan_interfaces(705)
+
+        assert_that(vlan_interfaces, equal_to(["xe-0/0/9"]))
+
+    def test_get_vlan_interfaces_nonexisting_vlan(self):
+        self.switch.in_transaction = False
+        self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
+                    <filter>
+                      <configuration>
+                        <vlans>
+                          <vlan>
+                            <vlan-id>9999999</vlan-id>
+                          </vlan>
+                        </vlans>
+                        <interfaces />
+                      </configuration>
+                    </filter>
+                """)).and_return(a_configuration("""
+                    <vlans />
+                    <interfaces>
+                        <interface>
+                          <name>xe-0/0/9</name>
+                          <unit>
+                            <family>
+                              <ethernet-switching>
+                                <vlan>
+                                  <members>705</members>
+                                </vlan>
+                              </ethernet-switching>
+                            </family>
+                          </unit>
+                        </interface>
+                    </interfaces>
+                """))
+        with self.assertRaises(UnknownVlan):
+            self.switch.get_vlan_interfaces("9999999")
+
     def test_get_vlan_with_no_interface(self):
         self.switch.in_transaction = False
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""


### PR DESCRIPTION
Also change the internal method is_vlan_in_interface_members(vlan_id, vlan_name, members_node)
to _get_vlan_interfaces_from_node(vlan_node, interface_nodes)