### PR TITLE
Add the definition of get_vlan_interfaces on SwitchBase

### DIFF
--- a/netman/adapters/switches/remote.py
+++ b/netman/adapters/switches/remote.py
@@ -135,6 +135,9 @@ class RemoteSwitch(SwitchBase):
     def remove_vlan(self, number):
         self.delete("/vlans/{0}".format(str(number)))
 
+    def get_vlan_interfaces(self, vlan_number):
+        return self.get("/vlans/{}/interfaces".format(vlan_number)).json()
+
     def set_vlan_access_group(self, vlan_number, direction, name):
         self.put('/vlans/{vlan_number}/access-groups/{direction}'.format(
             vlan_number=vlan_number,

--- a/netman/api/doc_config/api_samples/get_switch_hostname_vlans_vlan_interfaces.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_vlans_vlan_interfaces.json
@@ -1,0 +1,1 @@
+["ethernet 1/4", "FastEthernet0/3", "GigabitEthernet0/8"]

--- a/netman/api/switch_api.py
+++ b/netman/api/switch_api.py
@@ -32,6 +32,7 @@ class SwitchApi(SwitchApiBase):
         server.add_url_rule('/switches/<hostname>/vlans', view_func=self.add_vlan, methods=['POST'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>', view_func=self.get_vlan, methods=['GET'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>', view_func=self.remove_vlan, methods=['DELETE'])
+        server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/interfaces', view_func=self.get_vlan_interfaces, methods=['GET'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/ips', view_func=self.add_ip, methods=['POST'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/ips/<path:ip_network>', view_func=self.remove_ip, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/vrrp-groups', view_func=self.add_vrrp_group, methods=['POST'])
@@ -94,6 +95,25 @@ class SwitchApi(SwitchApiBase):
         vlans = sorted(switch.get_vlans(), key=lambda x: x.number)
 
         return 200, [vlan.to_api(v) for v in vlans]
+
+    @to_response
+    @resource(Switch, Vlan)
+    def get_vlan_interfaces(self, switch, vlan_number):
+        """
+        Displays interfaces use in a VLAN
+
+        :arg str hostname: Hostname or IP of the switch
+        :arg int vlan_number: Vlan number, between 1 and 4096
+        :code 200 OK:
+
+        Example output:
+
+        .. literalinclude:: ../doc_config/api_samples/get_switch_hostname_vlans_vlan_interfaces.json
+            :language: json
+
+        """
+
+        return 200, switch.get_vlan_interfaces(vlan_number)
 
     @to_response
     @resource(Switch, Vlan)

--- a/netman/core/objects/switch_base.py
+++ b/netman/core/objects/switch_base.py
@@ -86,6 +86,9 @@ class SwitchOperations(BackwardCompatibleSwitchOperations):
     def unset_interface_native_vlan(self, interface_id):
         raise NotImplementedError()
 
+    def get_vlan_interfaces(self, vlan_number):
+        raise NotImplementedError()
+
     def add_ip_to_vlan(self, vlan_number, ip_network):
         raise NotImplementedError()
 


### PR DESCRIPTION
Also ensure that the switch is exposed to the api and that the remote switch is able to call it.