### PR TITLE
Changed value errors for local exceptions

### DIFF
--- a/netman/adapters/switches/brocade.py
+++ b/netman/adapters/switches/brocade.py
@@ -27,7 +27,8 @@ from netman.core.objects.access_groups import IN, OUT
 from netman.core.objects.exceptions import IPNotAvailable, UnknownIP, UnknownVlan, UnknownAccessGroup, BadVlanNumber, \
     BadVlanName, UnknownInterface, TrunkVlanNotSet, VlanVrfNotSet, UnknownVrf, BadVrrpTimers, BadVrrpPriorityNumber, \
     BadVrrpTracking, VrrpAlreadyExistsForVlan, VrrpDoesNotExistForVlan, NoIpOnVlanForVrrp, BadVrrpAuthentication, \
-    BadVrrpGroupNumber, DhcpRelayServerAlreadyExists, UnknownDhcpRelayServer, VlanAlreadyExist, NetmanException
+    BadVrrpGroupNumber, DhcpRelayServerAlreadyExists, UnknownDhcpRelayServer, VlanAlreadyExist, NetmanException, \
+    InvalidAccessGroupName
 from netman.core.objects.interface import Interface
 from netman.core.objects.interface_states import OFF, ON
 from netman.core.objects.port_modes import ACCESS, TRUNK
@@ -278,7 +279,7 @@ class Brocade(SwitchBase):
                 self.shell.do("no ip access-group {} {}".format(vlan.access_groups[direction], {IN: 'in', OUT: 'out'}[direction]))
             result = self.shell.do("ip access-group {} {}".format(name, {IN: 'in', OUT: 'out'}[direction]))
             if len(result) > 0 and not result[0].startswith("Warning:"):
-                raise ValueError("Access group name \"{}\" is invalid".format(name))
+                raise InvalidAccessGroupName(name)
 
     def unset_vlan_access_group(self, vlan_number, direction):
         vlan = self._get_vlan(vlan_number, include_vif_data=True)

--- a/netman/adapters/switches/cisco.py
+++ b/netman/adapters/switches/cisco.py
@@ -22,7 +22,7 @@ from netman.core.objects.access_groups import IN, OUT
 from netman.core.objects.exceptions import IPNotAvailable, UnknownVlan, UnknownIP, UnknownAccessGroup, BadVlanNumber, \
     BadVlanName, UnknownInterface, UnknownVrf, VlanVrfNotSet, IPAlreadySet, VrrpAlreadyExistsForVlan, BadVrrpGroupNumber, \
     BadVrrpPriorityNumber, VrrpDoesNotExistForVlan, BadVrrpTimers, BadVrrpTracking, UnknownDhcpRelayServer, DhcpRelayServerAlreadyExists, \
-    VlanAlreadyExist, UnknownBond
+    VlanAlreadyExist, UnknownBond, InvalidAccessGroupName
 from netman.core.objects.interface import Interface
 from netman.core.objects.interface_states import OFF
 from netman.core.objects.port_modes import DYNAMIC, ACCESS, TRUNK
@@ -250,7 +250,7 @@ class Cisco(SwitchBase):
         with self.config(), self.interface_vlan(vlan_number):
             result = self.ssh.do("ip access-group {} {}".format(name, 'in' if direction == IN else 'out'))
             if len(result) > 0:
-                raise ValueError("Access group name \"{}\" is invalid".format(name))
+                raise InvalidAccessGroupName(name)
 
     def unset_vlan_access_group(self, vlan_number, direction):
         vlan = self.get_vlan_interface_data(vlan_number)

--- a/netman/api/api_utils.py
+++ b/netman/api/api_utils.py
@@ -20,7 +20,7 @@ from flask import make_response, request, Response, current_app
 from werkzeug.routing import BaseConverter
 from netman.api import NETMAN_API_VERSION
 
-from netman.core.objects.exceptions import UnknownResource, Conflict
+from netman.core.objects.exceptions import UnknownResource, Conflict, InvalidValue
 
 
 def to_response(fn):
@@ -36,7 +36,7 @@ def to_response(fn):
                     response = json_response(data, code)
                 else:
                     response = make_response("", code)
-        except (BadRequest, ValueError) as e:
+        except InvalidValue as e:
             response = exception_to_response(e, 400)
         except UnknownResource as e:
             response = exception_to_response(e, 404)
@@ -94,7 +94,7 @@ class RegexConverter(BaseConverter):
         self.regex = items[0]
 
 
-class BadRequest(Exception):
+class BadRequest(InvalidValue):
     pass
 
 

--- a/netman/core/objects/exceptions.py
+++ b/netman/core/objects/exceptions.py
@@ -19,6 +19,11 @@ class NetmanException(Exception):
     pass
 
 
+class InvalidValue(NetmanException):
+    def __init__(self, msg="Invalid Value"):
+        super(InvalidValue, self).__init__(msg)
+
+
 class UnknownResource(NetmanException):
     def __init__(self, msg="Resource not found"):
         super(UnknownResource, self).__init__(msg)
@@ -136,55 +141,55 @@ class VlanAlreadyInTrunk(Conflict):
 
 class VrrpAlreadyExistsForVlan(Conflict):
     def __init__(self, vlan=None, vrrp_group_id=None):
-        Conflict.__init__(self, "Vrrp group {group} is already in use on vlan {vlan}".format(group=vrrp_group_id, vlan=vlan))
+        super(VrrpAlreadyExistsForVlan, self).__init__("Vrrp group {group} is already in use on vlan {vlan}".format(group=vrrp_group_id, vlan=vlan))
 
 
-class VrrpDoesNotExistForVlan(ValueError):
+class VrrpDoesNotExistForVlan(InvalidValue):
     def __init__(self, vlan=None, vrrp_group_id=None):
-        ValueError.__init__(self, "Vrrp group {group} does not exist for vlan {vlan}".format(group=vrrp_group_id, vlan=vlan))
+        super(VrrpDoesNotExistForVlan, self).__init__("Vrrp group {group} does not exist for vlan {vlan}".format(group=vrrp_group_id, vlan=vlan))
 
 
-class NoIpOnVlanForVrrp(ValueError):
+class NoIpOnVlanForVrrp(InvalidValue):
     def __init__(self, vlan=None):
-        ValueError.__init__(self, "Vlan {vlan} needs an IP before configuring VRRP".format(vlan=vlan))
+        super(NoIpOnVlanForVrrp, self).__init__("Vlan {vlan} needs an IP before configuring VRRP".format(vlan=vlan))
 
 
-class BadVlanNumber(ValueError):
+class BadVlanNumber(InvalidValue):
     def __init__(self):
         super(BadVlanNumber, self).__init__("Vlan number is invalid")
 
 
-class BadInterfaceDescription(ValueError):
+class BadInterfaceDescription(InvalidValue):
     def __init__(self, desc=None):
         super(BadInterfaceDescription, self).__init__("Invalid description : {}".format(desc))
 
 
-class BadVrrpGroupNumber(ValueError):
+class BadVrrpGroupNumber(InvalidValue):
     def __init__(self, minimum=None, maximum=None):
         super(BadVrrpGroupNumber, self).__init__("VRRP group number is invalid, must be contained between {min} and {max}".format(min=minimum, max=maximum))
 
 
-class BadVrrpPriorityNumber(ValueError):
+class BadVrrpPriorityNumber(InvalidValue):
     def __init__(self, minimum=None, maximum=None):
         super(BadVrrpPriorityNumber, self).__init__("VRRP priority value is invalid, must be contained between {min} and {max}".format(min=minimum, max=maximum))
 
 
-class BadVrrpTimers(ValueError):
+class BadVrrpTimers(InvalidValue):
     def __init__(self):
         super(BadVrrpTimers, self).__init__("VRRP timers values are invalid")
 
 
-class BadVrrpAuthentication(ValueError):
+class BadVrrpAuthentication(InvalidValue):
     def __init__(self):
         super(BadVrrpAuthentication, self).__init__("VRRP authentication is invalid")
 
 
-class BadVrrpTracking(ValueError):
+class BadVrrpTracking(InvalidValue):
     def __init__(self):
         super(BadVrrpTracking, self).__init__("VRRP tracking values are invalid")
 
 
-class BadVlanName(ValueError):
+class BadVlanName(InvalidValue):
     def __init__(self):
         super(BadVlanName, self).__init__("Vlan name is invalid")
 
@@ -199,7 +204,7 @@ class UnableToAcquireLock(UnavailableResource):
         super(UnableToAcquireLock, self).__init__("Unable to acquire a lock in a timely fashion")
 
 
-class BadBondNumber(ValueError):
+class BadBondNumber(InvalidValue):
     def __init__(self):
         super(BadBondNumber, self).__init__("Bond number is invalid")
 
@@ -219,7 +224,7 @@ class UnknownBond(UnknownResource):
         super(UnknownBond, self).__init__("Bond {} not found".format(number))
 
 
-class BadBondLinkSpeed(ValueError):
+class BadBondLinkSpeed(InvalidValue):
     def __init__(self):
         super(BadBondLinkSpeed, self).__init__("Malformed bond link speed")
 
@@ -229,7 +234,7 @@ class UnknownSwitch(UnknownResource):
         super(UnknownSwitch, self).__init__("Switch \"{0}\" is not configured".format(name))
 
 
-class MalformedSwitchSessionRequest(ValueError):
+class MalformedSwitchSessionRequest(InvalidValue):
     def __init__(self):
         super(MalformedSwitchSessionRequest, self).__init__("Malformed switch session request")
 
@@ -252,3 +257,8 @@ class CommandTimeout(Exception):
 class CouldNotConnect(Exception):
     def __init__(self, host=None, port=None):
         super(CouldNotConnect, self).__init__("Could not connect to {} on port {}".format(host, port))
+
+
+class InvalidAccessGroupName(InvalidValue):
+    def __init__(self, name=None):
+        super(InvalidAccessGroupName, self).__init__("Access Group Name is invalid: {}".format(name))

--- a/tests/adapters/switches/brocade_test.py
+++ b/tests/adapters/switches/brocade_test.py
@@ -27,7 +27,7 @@ from netman.core.objects.access_groups import IN, OUT
 from netman.core.objects.exceptions import IPNotAvailable, UnknownVlan, UnknownIP, UnknownAccessGroup, BadVlanNumber, \
     BadVlanName, UnknownInterface, TrunkVlanNotSet, UnknownVrf, VlanVrfNotSet, VrrpAlreadyExistsForVlan, BadVrrpPriorityNumber, BadVrrpGroupNumber, \
     BadVrrpTimers, BadVrrpTracking, NoIpOnVlanForVrrp, VrrpDoesNotExistForVlan, UnknownDhcpRelayServer, DhcpRelayServerAlreadyExists, \
-    VlanAlreadyExist
+    VlanAlreadyExist, InvalidAccessGroupName
 from netman.core.objects.interface_states import OFF, ON
 from netman.core.objects.port_modes import ACCESS, TRUNK
 from netman.core.objects.switch_descriptor import SwitchDescriptor
@@ -1330,10 +1330,10 @@ class BrocadeTest(unittest.TestCase):
         ])
         self.shell_mock.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
 
-        with self.assertRaises(ValueError) as expect:
+        with self.assertRaises(InvalidAccessGroupName) as expect:
             self.switch.set_vlan_access_group(2500, OUT, "TheAcc essGroup")
 
-        assert_that(str(expect.exception), equal_to("Access group name \"TheAcc essGroup\" is invalid"))
+        assert_that(str(expect.exception), equal_to("Access Group Name is invalid: TheAcc essGroup"))
 
     def test_set_access_group_needs_to_remove_actual_access_group_to_override_it(self):
         self.shell_mock.should_receive("do").with_args("show vlan 2500").once().ordered().and_return(

--- a/tests/adapters/switches/cisco_test.py
+++ b/tests/adapters/switches/cisco_test.py
@@ -28,7 +28,7 @@ from netman.core.objects.exceptions import IPNotAvailable, UnknownVlan, UnknownI
     BadVlanName, UnknownInterface, UnknownVrf, VlanVrfNotSet, IPAlreadySet, BadVrrpGroupNumber, \
     BadVrrpPriorityNumber, VrrpDoesNotExistForVlan, VrrpAlreadyExistsForVlan, BadVrrpTimers, \
     BadVrrpTracking, DhcpRelayServerAlreadyExists, UnknownDhcpRelayServer, VlanAlreadyExist, \
-    UnknownBond
+    UnknownBond, InvalidAccessGroupName
 from netman.core.objects.interface_states import OFF, ON
 from netman.core.objects.port_modes import ACCESS, TRUNK, DYNAMIC
 from netman.core.objects.switch_descriptor import SwitchDescriptor
@@ -1612,10 +1612,10 @@ class CiscoTest(unittest.TestCase):
         ])
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
 
-        with self.assertRaises(ValueError) as expect:
+        with self.assertRaises(InvalidAccessGroupName) as expect:
             self.switch.set_vlan_access_group(2500, OUT, "TheAc cessGroup")
 
-        assert_that(str(expect.exception), equal_to("Access group name \"TheAc cessGroup\" is invalid"))
+        assert_that(str(expect.exception), equal_to("Access Group Name is invalid: TheAc cessGroup"))
 
     def test_set_access_group_without_interface_creates_it(self):
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface vlan 2500").once().ordered().and_return([

--- a/tests/api/switch_api_test.py
+++ b/tests/api/switch_api_test.py
@@ -28,7 +28,7 @@ from netman.api.switch_api import SwitchApi
 from netman.api.switch_session_api import SwitchSessionApi
 from netman.core.objects.access_groups import IN, OUT
 from netman.core.objects.exceptions import IPNotAvailable, UnknownIP, UnknownVlan, UnknownAccessGroup, UnknownInterface, \
-    UnknownSwitch, OperationNotCompleted, UnknownSession, SessionAlreadyExists
+    UnknownSwitch, OperationNotCompleted, UnknownSession, SessionAlreadyExists, InvalidAccessGroupName
 from netman.core.objects.interface import Interface
 from netman.core.objects.port_modes import ACCESS, TRUNK, DYNAMIC, BOND_MEMBER
 from netman.core.objects.vlan import Vlan
@@ -955,13 +955,13 @@ class SwitchApiTest(BaseApiTest):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()
         self.switch_mock.should_receive('set_vlan_access_group').with_args(2500, OUT, "blablabla").once().ordered() \
-            .and_raise(ValueError('Access group name \"blablabla\" is invalid'))
+            .and_raise(InvalidAccessGroupName("blablabla"))
         self.switch_mock.should_receive('disconnect').once().ordered()
 
         result, code = self.put("/switches/my.switch/vlans/2500/access-groups/out", raw_data="blablabla")
 
         assert_that(code, equal_to(400))
-        assert_that(result, equal_to({'error': 'Access group name \"blablabla\" is invalid'}))
+        assert_that(result, equal_to({'error': 'Access Group Name is invalid: blablabla'}))
 
     def delete_put_access_groups_in(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()


### PR DESCRIPTION
This way we know what to handle and what to not handle, catching ValueError was hiding illegitimate error for which a stack trace and a 500 error was required

fixes #99