### PR TITLE
Cached switch unset interface state

### DIFF
--- a/netman/adapters/switches/cached.py
+++ b/netman/adapters/switches/cached.py
@@ -291,6 +291,10 @@ class CachedSwitch(SwitchBase):
         self.real_switch.set_interface_state(interface_id, state)
         self.interfaces_cache[interface_id].shutdown = (state == OFF)
 
+    def unset_interface_state(self, interface_id):
+        self.real_switch.unset_interface_state(interface_id)
+        self.interfaces_cache[interface_id].shutdown = False
+
     def add_bond(self, number):
         self.real_switch.add_bond(number)
         self.bonds_cache[number] = Bond(number=number)

--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -413,11 +413,9 @@ class Juniper(SwitchBase):
 
                 self._push(update)
 
-    def set_interface_state(self, interface_id, state):
+    def set_interface_state(self, interface_id, state=ON):
         update = Update()
-        update.add_interface(interface_main_update(interface_id, [
-            to_ele("<disable />") if state is OFF else to_ele("<enable />")
-        ]))
+        update.add_interface(interface_state_update(interface_id, state))
 
         try:
             self._push(update)
@@ -425,7 +423,8 @@ class Juniper(SwitchBase):
             self.logger.info("actual setting error was {}".format(e))
             raise UnknownInterface(interface_id)
 
-
+    def unset_interface_state(self, interface_id):
+        self.set_interface_state(interface_id)
 
     def set_interface_lldp_state(self, interface_id, enabled):
         config = self.query(one_interface(interface_id), one_protocol_interface("lldp", interface_id))
@@ -825,6 +824,15 @@ def interface_removal(name):
         <interface operation="delete">
             <name>{}</name>
         </interface>""".format(name))
+
+
+def interface_state_update(name, state):
+    interface_state = """<disable />""" if state is OFF else """<disable operation="delete" />"""
+    return to_ele("""
+        <interface>
+            <name>{}</name>
+            {}
+        </interface>""".format(name, interface_state))
 
 
 def vlan_removal(name):

--- a/tests/adapters/switches/cached_switch_test.py
+++ b/tests/adapters/switches/cached_switch_test.py
@@ -321,6 +321,34 @@ class CacheSwitchTest(unittest.TestCase):
             self.switch.get_interfaces(),
             is_([Interface('xe-1/0/2', shutdown=False)]))
 
+    def test_unset_interface_state_when_interface_is_on(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2', shutdown=True)])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("unset_interface_state").once() \
+            .with_args('xe-1/0/2')
+
+        self.switch.unset_interface_state('xe-1/0/2')
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', shutdown=False)]))
+
+    def test_unset_interface_state_when_interface_is_off(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2', shutdown=False)])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("unset_interface_state").once() \
+            .with_args('xe-1/0/2')
+
+        self.switch.unset_interface_state('xe-1/0/2')
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', shutdown=False)]))
+
     def test_set_interface_native_vlan(self):
         self.real_switch_mock.should_receive("get_interfaces").once() \
             .and_return([Interface('xe-1/0/2')])

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -4086,14 +4086,14 @@ class JuniperTest(unittest.TestCase):
 
         assert_that(str(expect.exception), contains_string("Unknown interface ge-0/0/99"))
 
-    def test_enable_interface_succeeds(self):
+    def test_set_interface_state_to_on_succeeds(self):
         self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
             <config>
               <configuration>
                 <interfaces>
                   <interface>
                     <name>ge-0/0/6</name>
-                    <enable />
+                    <disable operation="delete" />
                   </interface>
                 </interfaces>
               </configuration>
@@ -4102,14 +4102,47 @@ class JuniperTest(unittest.TestCase):
 
         self.switch.set_interface_state("ge-0/0/6", ON)
 
-    def test_enable_interface_on_unkown_interface_raises(self):
+    def test_set_interface_state_to_off_succeeds(self):
+        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
+            <config>
+              <configuration>
+                <interfaces>
+                  <interface>
+                    <name>ge-0/0/6</name>
+                    <disable />
+                  </interface>
+                </interfaces>
+              </configuration>
+            </config>
+        """)).and_return(an_ok_response())
+
+        self.switch.set_interface_state("ge-0/0/6", OFF)
+
+    def test_unset_interface_state_succeeds(self):
+
+        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
+            <config>
+              <configuration>
+                <interfaces>
+                  <interface>
+                    <name>ge-0/0/6</name>
+                    <disable operation="delete" />
+                  </interface>
+                </interfaces>
+              </configuration>
+            </config>
+        """)).and_return(an_ok_response())
+
+        self.switch.unset_interface_state("ge-0/0/6")
+
+    def test_set_interface_state_to_on_unknown_interface_raises(self):
         self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
             <config>
               <configuration>
                 <interfaces>
                   <interface>
                     <name>ge-0/0/99</name>
-                    <enable />
+                    <disable operation="delete"/>
                   </interface>
                 </interfaces>
               </configuration>
@@ -4127,23 +4160,7 @@ class JuniperTest(unittest.TestCase):
 
         assert_that(str(expect.exception), contains_string("Unknown interface ge-0/0/99"))
 
-    def test_disable_interface_succeeds(self):
-        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
-            <config>
-              <configuration>
-                <interfaces>
-                  <interface>
-                    <name>ge-0/0/6</name>
-                    <disable />
-                  </interface>
-                </ienablenterfaces>
-              </configuration>
-            </config>
-        """)).and_return(an_ok_response())
-
-        self.switch.set_interface_state("ge-0/0/6", OFF)
-
-    def test_disable_interface_on_unkown_interface_raises(self):
+    def test_set_interface_state_to_off_unknown_interface_raises(self):
         self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
             <config>
               <configuration>
@@ -5352,6 +5369,7 @@ class IsXmlFlexmockArgMatcher(object):
                 else:
                     assert_that(actual[i].text is not None, "Node is " + node.tag)
                     assert_that(node.text.strip(), equal_to(actual[i].text.strip()))
+            assert_that(actual[i].attrib, has_length(len(node.attrib)))
             for name, value in node.attrib.items():
                 assert_that(actual[i].attrib, has_key(name))
                 assert_that(actual[i].attrib[name], equal_to(value))


### PR DESCRIPTION
This implementation offers support for unsetting an interface state on the cached switch. 