### PR TITLE
Deprecated some members of SwitchDescriptor

### DIFF
--- a/netman/core/objects/switch_descriptor.py
+++ b/netman/core/objects/switch_descriptor.py
@@ -11,26 +11,46 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import warnings
 
 from netman.core.objects import Model
 
 
 class SwitchDescriptor(Model):
-    def __init__(self, model, hostname, username=None, password=None, port=None,
-                 default_vrf=None, default_lan_acl_in=None, default_lan_acl_out=None,
-                 trunked_interfaces=None, parking_vlan=None, netman_server=None, default_port_speed=None,
-                 vrrp_tracking_object=None):
+    def __init__(self, model, hostname, username=None, password=None, port=None, netman_server=None, **kwargs):
         self.model = model
         self.hostname = hostname
         self.username = username
         self.password = password
         self.port = port
-
-        self.default_vrf = default_vrf
-        self.default_lan_acl_in = default_lan_acl_in
-        self.default_lan_acl_out = default_lan_acl_out
-        self.default_port_speed = default_port_speed
-        self.trunked_interfaces = trunked_interfaces
-        self.parking_vlan = parking_vlan
         self.netman_server = netman_server
-        self.vrrp_tracking_object = vrrp_tracking_object
+
+        self._deprecated_values = {}
+        for m in _deprecated_members:
+            if m in kwargs:
+                setattr(self, m, kwargs.get(m))
+
+
+_deprecated_members = ["default_vrf", "default_lan_acl_in", "default_lan_acl_out", "default_port_speed",
+                       "trunked_interfaces", "parking_vlan", "vrrp_tracking_object"]
+
+
+def _deprecation_warning(member):
+    warnings.warn("Deprecated member {} is not used by Netman, define it elsewhere for your needs".format(member),
+                  DeprecationWarning)
+
+
+def _add_deprecated_property(m):
+    def get_that(switch_descriptor):
+        _deprecation_warning(m)
+        return switch_descriptor._deprecated_values.get(m)
+
+    def set_that(switch_descriptor, value):
+        _deprecation_warning(m)
+        switch_descriptor._deprecated_values[m] = value
+
+    setattr(SwitchDescriptor, m, property(get_that, set_that))
+
+
+for m in _deprecated_members:
+    _add_deprecated_property(m)

--- a/tests/core/objects/switch_descriptor_test.py
+++ b/tests/core/objects/switch_descriptor_test.py
@@ -1,0 +1,74 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import TestCase
+
+from hamcrest import assert_that, is_
+
+from netman.core.objects.switch_descriptor import SwitchDescriptor
+from tests import ignore_deprecation_warnings
+
+
+class SwitchDescriptorTest(TestCase):
+
+    @ignore_deprecation_warnings
+    def test_backward_compatibility_on_members_given_to_ctor(self):
+        s = SwitchDescriptor("model", "name",
+                             default_vrf="String",
+                             default_lan_acl_in="String",
+                             default_lan_acl_out="String",
+                             trunked_interfaces=["list"],
+                             parking_vlan=123,
+                             default_port_speed="String",
+                             vrrp_tracking_object="String")
+
+        assert_that(s.default_vrf, is_("String"))
+        assert_that(s.default_lan_acl_in, is_("String"))
+        assert_that(s.default_lan_acl_out, is_("String"))
+        assert_that(s.trunked_interfaces, is_(["list"]))
+        assert_that(s.parking_vlan, is_(123))
+        assert_that(s.default_port_speed, is_("String"))
+        assert_that(s.vrrp_tracking_object, is_("String"))
+
+    @ignore_deprecation_warnings
+    def test_backward_compatibility_on_get_and_Set(self):
+        s = SwitchDescriptor("model", "name")
+
+        assert_that(s.default_vrf, is_(None))
+        assert_that(s.default_lan_acl_in, is_(None))
+        assert_that(s.default_lan_acl_out, is_(None))
+        assert_that(s.trunked_interfaces, is_(None))
+        assert_that(s.parking_vlan, is_(None))
+        assert_that(s.default_port_speed, is_(None))
+        assert_that(s.vrrp_tracking_object, is_(None))
+
+        s.default_vrf = "String"
+        assert_that(s.default_vrf, is_("String"))
+
+        s.default_lan_acl_in="String"
+        assert_that(s.default_lan_acl_in, is_("String"))
+
+        s.default_lan_acl_out="String"
+        assert_that(s.default_lan_acl_out, is_("String"))
+
+        s.trunked_interfaces=["list"]
+        assert_that(s.trunked_interfaces, is_(["list"]))
+
+        s.parking_vlan=123
+        assert_that(s.parking_vlan, is_(123))
+
+        s.default_port_speed="String"
+        assert_that(s.default_port_speed, is_("String"))
+
+        s.vrrp_tracking_object="String"
+        assert_that(s.vrrp_tracking_object, is_("String"))


### PR DESCRIPTION
Those are remnant of an old system association and are not used in netman at all, so no reason to define them here.