### PR TITLE
Make fake-switch have priority over MockSsh

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,9 +2,9 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 -e git+https://github.com/has207/flexmock.git@15570d8b4999cd62e6fdf75d90431d31f9def6a3#egg=flexmock
+fake-switches>=1.0.22
 MockSSH>=1.4.1
 Sphinx
 sphinxcontrib-httpdomain
-fake-switches>=1.0.22
 gunicorn>=19.4.5
 futures>=3.0.4


### PR DESCRIPTION
MockSsh = any
Fake-switches depends == 15.5.0,


Pip currently installs any because it takes the first found.