### PR TITLE
Ensure that interface can be set and unset twice without failing.

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -421,7 +421,10 @@ class Juniper(SwitchBase):
             self._push(update)
         except RPCError as e:
             self.logger.info("actual setting error was {}".format(e))
-            raise UnknownInterface(interface_id)
+            # When sending a "delete operation" on a nonexistent element <disable />, this is the error that is thrown.
+            # It's ignored because the result of this operation would be the same as if the command was successful.
+            if e.message != "statement not found: ":
+                raise UnknownInterface(interface_id)
 
     def unset_interface_state(self, interface_id):
         self.set_interface_state(interface_id, state=ON)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 -e git+https://github.com/has207/flexmock.git@15570d8b4999cd62e6fdf75d90431d31f9def6a3#egg=flexmock
-fake-switches>=1.0.23
+fake-switches>=1.0.25
 MockSSH>=1.4.1
 Sphinx
 sphinxcontrib-httpdomain

--- a/tests/adapters/compliance_tests/set_interface_state_test.py
+++ b/tests/adapters/compliance_tests/set_interface_state_test.py
@@ -40,6 +40,13 @@ class SetInterfaceStateTest(ComplianceTestCase):
             self.client.set_interface_state('ge-0/0/128', state=ON)
         assert_that(str(exc.exception), contains_string("Unknown interface ge-0/0/128"))
 
+    def test_set_an_interface_twice_works(self):
+        self.try_to.set_interface_state(self.test_port, ON)
+        self.try_to.set_interface_state(self.test_port, ON)
+
+        self.try_to.set_interface_state(self.test_port, OFF)
+        self.try_to.set_interface_state(self.test_port, OFF)
+
     def tearDown(self):
         self.janitor.unset_interface_state(self.test_port)
         super(SetInterfaceStateTest, self).tearDown()

--- a/tests/adapters/compliance_tests/unset_interface_state_test.py
+++ b/tests/adapters/compliance_tests/unset_interface_state_test.py
@@ -35,6 +35,16 @@ class UnsetInterfaceStateTest(ComplianceTestCase):
 
         assert_that(self.client.get_interface(self.test_port).shutdown, is_(default_state))
 
+    def test_unset_an_interface_twice_works(self):
+        default_state = self.client.get_interface(self.test_port).shutdown
+        self.try_to.set_interface_state(self.test_port, ON)
+
+        self.client.unset_interface_state(self.test_port)
+        self.client.unset_interface_state(self.test_port)
+
+        self.try_to.set_interface_state(self.test_port, default_state)
+        assert_that(self.client.get_interface(self.test_port).shutdown, is_(default_state))
+
     def test_fails_with_unknown_interface(self):
         with self.assertRaises(UnknownInterface):
             self.client.unset_interface_state('ge-0/0/1nonexistent2000')

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -4160,6 +4160,27 @@ class JuniperTest(unittest.TestCase):
 
         assert_that(str(expect.exception), contains_string("Unknown interface ge-0/0/99"))
 
+    def test_unset_interface_state_without_disabled(self):
+        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
+            <config>
+              <configuration>
+                <interfaces>
+                  <interface>
+                    <name>ge-0/0/6</name>
+                    <disable operation="delete" />
+                  </interface>
+                </interfaces>
+              </configuration>
+            </config>
+        """)).and_raise(RPCError(to_ele(textwrap.dedent("""
+            <rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/11.4R1/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <error-severity>warning</error-severity>
+            <error-path>[edit interfaces ge-0/0/6]</error-path>
+            <error-message>statement not found: </error-message>
+            </rpc-error>"""))))
+
+        self.switch.unset_interface_state("ge-0/0/6")
+
     def test_set_interface_state_to_on_unknown_interface_raises(self):
         self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
             <config>


### PR DESCRIPTION
This adds robustness to netman calls. A transition of state with an object
 that has already the target state shoudn't raise.