### PR TITLE
rename password_prompt for prompt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ mock>=1.0.1
 pyhamcrest>=1.6
 flexmock>=0.10.2
 fake-switches>=1.0.25
-MockSSH>=1.4.1
+MockSSH>=1.4.2
 Sphinx
 sphinxcontrib-httpdomain
 gunicorn>=19.4.5

--- a/tests/adapters/shell/terminal_client_test.py
+++ b/tests/adapters/shell/terminal_client_test.py
@@ -34,7 +34,7 @@ from tests.adapters.shell.mock_terminal_commands import passwd_change_protocol_p
 command_passwd = MockSSH.PromptingCommand(
     name='passwd',
     password='1234',
-    password_prompt="Password:",
+    prompt="Password:",
     success_callbacks=[passwd_change_protocol_prompt],
     failure_callbacks=[passwd_write_password_to_transport])
 


### PR DESCRIPTION
This changes has been introduced in Mockssh 1.4.2