### PR TITLE
reset_interface for juniper and QFX

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -318,6 +318,22 @@ class Juniper(SwitchBase):
                     raise UnknownVlan(vlan)
                 raise
 
+    def reset_interface(self, interface_id):
+        content = to_ele("""
+            <interface operation=\"replace\">
+                <name>{0}</name>
+            </interface>
+        """.format(interface_id))
+        update = Update()
+        update.add_interface(content)
+
+        try:
+            self._push(update)
+        except RPCError as e:
+            if "port value outside range" in e.message:
+                raise UnknownInterface(interface_id)
+            raise
+
     def unset_interface_native_vlan(self, interface_id):
         interface = self.get_interface(interface_id)
 

--- a/netman/core/objects/switch_base.py
+++ b/netman/core/objects/switch_base.py
@@ -89,6 +89,9 @@ class SwitchOperations(BackwardCompatibleSwitchOperations):
     def unset_interface_native_vlan(self, interface_id):
         raise NotImplementedError()
 
+    def reset_interface(self, interface_id):
+        raise NotImplementedError()
+
     def get_vlan_interfaces(self, vlan_number):
         raise NotImplementedError()
 


### PR DESCRIPTION
This will allow to reset the ports to the default configuration on the
switch.