### PR TITLE
Add compliance test reset interface

### DIFF
--- a/netman/adapters/switches/cached.py
+++ b/netman/adapters/switches/cached.py
@@ -226,6 +226,10 @@ class CachedSwitch(SwitchBase):
         self.real_switch.set_access_vlan(interface_id, vlan)
         self.interfaces_cache[interface_id].access_vlan = vlan
 
+    def reset_interface(self, interface_id):
+        self.real_switch.reset_interface(interface_id)
+        self.interfaces_cache.refresh_items.add(interface_id)
+
     def unset_interface_access_vlan(self, interface_id):
         self.real_switch.unset_interface_access_vlan(interface_id)
         self.interfaces_cache[interface_id].access_vlan = None

--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -318,6 +318,22 @@ class Juniper(SwitchBase):
                     raise UnknownVlan(vlan)
                 raise
 
+    def reset_interface(self, interface_id):
+        content = to_ele("""
+            <interface operation=\"replace\">
+                <name>{0}</name>
+            </interface>
+        """.format(interface_id))
+        update = Update()
+        update.add_interface(content)
+
+        try:
+            self._push(update)
+        except RPCError as e:
+            if "port value outside range" in e.message:
+                raise UnknownInterface(interface_id)
+            raise
+
     def unset_interface_native_vlan(self, interface_id):
         interface = self.get_interface(interface_id)
 

--- a/netman/adapters/switches/remote.py
+++ b/netman/adapters/switches/remote.py
@@ -184,6 +184,9 @@ class RemoteSwitch(SwitchBase):
     def set_access_vlan(self, interface_id, vlan):
         self.put("/interfaces/" + interface_id + '/access-vlan', raw_data=str(vlan))
 
+    def reset_interface(self, interface_id):
+        self.put("/interfaces/" + interface_id)
+
     def unset_interface_access_vlan(self, interface_id):
         self.delete("/interfaces/" + interface_id + '/access-vlan')
 

--- a/netman/api/switch_api.py
+++ b/netman/api/switch_api.py
@@ -21,7 +21,6 @@ from netman.api.validators import Switch, is_boolean, is_vlan_number, Interface,
     IPNetworkResource, is_access_group_name, Direction, is_vlan, is_bond, Bond, \
     is_bond_link_speed, is_bond_number, is_description, is_vrf_name, \
     is_vrrp_group, VrrpGroup, is_dict_with, optional, is_type
-from netman.core.objects.exceptions import UnknownInterface
 from netman.core.objects.interface_states import OFF, ON
 
 
@@ -46,6 +45,7 @@ class SwitchApi(SwitchApiBase):
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/dhcp-relay-server/<ip_network>', view_func=self.remove_dhcp_relay_server, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/icmp-redirects', view_func=self.set_vlan_icmp_redirects_state, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces', view_func=self.get_interfaces, methods=['GET'])
+        server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>', view_func=self.reset_interface, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>', view_func=self.get_interface, methods=['GET'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/shutdown', view_func=self.set_shutdown_state, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/shutdown', view_func=self.unset_shutdown_state, methods=['DELETE'])
@@ -429,6 +429,24 @@ class SwitchApi(SwitchApiBase):
         """
 
         switch.set_access_vlan(interface_id, vlan_number)
+        return 204, None
+
+    @to_response
+    @resource(Switch, Interface)
+    def reset_interface(self, switch, interface_id):
+        """
+        Reset the interface to it's default settings
+
+        Adding parameter to the interface is not yet supported. This requests only defaults the switch.
+
+        :arg str hostname: Hostname or IP of the switch
+        :arg str interface_id: Interface name (ex. ``FastEthernet0/1``, ``ethernet1/11``)
+
+        """
+
+        if request.get_data():
+            raise NotImplementedError('Providing data is not supported by this method')
+        switch.reset_interface(interface_id)
         return 204, None
 
     @to_response

--- a/netman/core/objects/switch_base.py
+++ b/netman/core/objects/switch_base.py
@@ -89,6 +89,9 @@ class SwitchOperations(BackwardCompatibleSwitchOperations):
     def unset_interface_native_vlan(self, interface_id):
         raise NotImplementedError()
 
+    def reset_interface(self, interface_id):
+        raise NotImplementedError()
+
     def get_vlan_interfaces(self, vlan_number):
         raise NotImplementedError()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 flexmock>=0.10.2
-fake-switches>=1.0.26
+fake-switches>=1.0.27
 MockSSH>=1.4.2
 Sphinx
 sphinxcontrib-httpdomain

--- a/tests/adapters/compliance_tests/reset_interface.py
+++ b/tests/adapters/compliance_tests/reset_interface.py
@@ -1,0 +1,69 @@
+from hamcrest import assert_that, is_
+
+from netman.core.objects.interface_states import ON, OFF
+from netman.core.objects.port_modes import ACCESS
+from tests.adapters.compliance_test_case import ComplianceTestCase
+
+
+class ResetInterfaceTest(ComplianceTestCase):
+    _dev_sample = "juniper"
+
+    def setUp(self):
+        super(ResetInterfaceTest, self).setUp()
+        self.interface_before = self.try_to.get_interface(self.test_port)
+
+    def test_reset_interface_reverts_trunk_vlans(self):
+        self.try_to.add_vlan(90)
+        self.addCleanup(self.janitor.remove_vlan, 90)
+
+        self.try_to.set_trunk_mode(self.test_port)
+        self.try_to.add_trunk_vlan(self.test_port, 90)
+
+        self.client.reset_interface(self.test_port)
+
+        assert_that(self.client.get_interface(self.test_port).trunk_vlans, is_(self.interface_before.trunk_vlans))
+
+    def test_reset_interface_reverts_trunk_native_vlan(self):
+        self.try_to.add_vlan(90)
+        self.addCleanup(self.janitor.remove_vlan, 90)
+
+        self.try_to.set_trunk_mode(self.test_port)
+        self.try_to.set_interface_native_vlan(self.test_port, 90)
+
+        self.client.reset_interface(self.test_port)
+
+        assert_that(self.client.get_interface(self.test_port).trunk_native_vlan,
+                    is_(self.interface_before.trunk_native_vlan))
+
+    def test_reset_interface_reverts_port_mode(self):
+        if self.interface_before.port_mode == ACCESS:
+            self.try_to.set_trunk_mode(self.test_port)
+        else:
+            self.try_to.set_access_mode(self.test_port)
+
+        self.client.reset_interface(self.test_port)
+
+        assert_that(self.try_to.get_interface(self.test_port).port_mode, is_(self.interface_before.port_mode))
+
+    def test_reset_interface_reverts_bond_master(self):
+        self.try_to.add_bond(42)
+        self.addCleanup(self.janitor.remove_bond, 42)
+
+        self.try_to.add_interface_to_bond(self.test_port, 42)
+
+        self.client.reset_interface(self.test_port)
+
+        actual_interface = self.try_to.get_interface(self.test_port)
+        assert_that(actual_interface.bond_master, is_(self.interface_before.bond_master))
+
+    def test_reset_interface_reverts_port_shutdown(self):
+        if not self.interface_before.shutdown or self.interface_before.shutdown is OFF:
+            self.try_to.set_interface_state(self.test_port, ON)
+        else:
+            self.try_to.set_interface_state(self.test_port, OFF)
+
+        self.client.reset_interface(self.test_port)
+
+        assert_that(self.client.get_interface(self.test_port).shutdown, is_(self.interface_before.shutdown))
+
+

--- a/tests/adapters/switches/cached_switch_test.py
+++ b/tests/adapters/switches/cached_switch_test.py
@@ -211,6 +211,18 @@ class CacheSwitchTest(unittest.TestCase):
             is_([Interface('eth0', access_vlan=123)])
         )
 
+    def test_reset_interface_invalidate_cache(self):
+        self.real_switch_mock.should_receive("get_interface").with_args("eth0").once().\
+            and_return([Interface('eth0')])
+        self.switch.get_interface('eth0')
+
+        self.real_switch_mock.should_receive("reset_interface").with_args('eth0')
+        self.switch.reset_interface('eth0')
+
+        self.real_switch_mock.should_receive("get_interface").with_args("eth0").once(). \
+            and_return([Interface('eth0')])
+        self.switch.get_interface('eth0')
+
     def test_unset_interface_access_vlan(self):
         self.real_switch_mock.should_receive("get_interfaces").once().and_return(
             [Interface('eth0', access_vlan=123)])

--- a/tests/adapters/switches/remote_test.py
+++ b/tests/adapters/switches/remote_test.py
@@ -979,6 +979,35 @@ class RemoteSwitchTest(unittest.TestCase):
 
         self.switch.set_access_vlan("ge-0/0/6", 1000)
 
+    def test_reset_interface(self):
+        self.requests_mock.should_receive("put").once().with_args(
+                url=self.netman_url+'/switches/toto/interfaces/ge-0/0/6',
+                headers=self.headers,
+                data=None
+        ).and_return(
+                Reply(
+                        content='',
+                        status_code=204))
+
+        self.switch.reset_interface("ge-0/0/6")
+
+    def test_reset_interface_with_unknown_interface_raises(self):
+        self.requests_mock.should_receive("put").once().with_args(
+                url=self.netman_url+'/switches/toto/interfaces/ne-0/0/66',
+                headers=self.headers,
+                data=None
+        ).and_return(
+                Reply(
+                        content=json.dumps({
+                            "error": "Interface ethernet ne-0/0/66 not found",
+                            "error-module": UnknownInterface.__module__,
+                            "error-class": UnknownInterface.__name__
+                        }),
+                        status_code=404))
+
+        with self.assertRaises(UnknownInterface):
+            self.switch.reset_interface('ne-0/0/66')
+
     def test_unset_interface_access_vlan(self):
         self.requests_mock.should_receive("delete").once().with_args(
             url=self.netman_url+'/switches/toto/interfaces/ge-0/0/6/access-vlan',

--- a/tests/api/switch_api_test.py
+++ b/tests/api/switch_api_test.py
@@ -426,6 +426,26 @@ class SwitchApiTest(BaseApiTest):
         })
         assert_that(code, equal_to(200))
 
+    def test_reset_interface(self):
+        self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
+        self.switch_mock.should_receive('connect').once().ordered()
+        self.switch_mock.should_receive('reset_interface').with_args('FastEthernet0/4').once().ordered()
+        self.switch_mock.should_receive('disconnect').once().ordered()
+
+        result, code = self.put("/switches/my.switch/interfaces/FastEthernet0/4")
+
+        assert_that(code, equal_to(204))
+
+    def test_put_interface_with_data_is_not_implemented(self):
+        self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
+        self.switch_mock.should_receive('connect').once().ordered()
+        self.switch_mock.should_receive('disconnect').once().ordered()
+
+        result, code = self.put("/switches/my.switch/interfaces/FastEthernet0/4",
+                                raw_data='providing data is not supported')
+
+        assert_that(code, equal_to(501))
+
     def test_set_interface_state_off(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()


### PR DESCRIPTION
This PR adds the reset_interface call to juniper and exposes it to the API.
See separate commit for *more* granulate changes.