### PR TITLE
Change the way request data is being obtained as call will be deprecated

### DIFF
--- a/netman/api/switch_api.py
+++ b/netman/api/switch_api.py
@@ -382,7 +382,7 @@ class SwitchApi(SwitchApiBase):
             ``trunk`` or ``access``
         """
 
-        mode = request.data.lower()
+        mode = request.get_data().lower()
         if mode == 'trunk':
             switch.set_trunk_mode(interface_id)
         elif mode == 'access':
@@ -404,7 +404,7 @@ class SwitchApi(SwitchApiBase):
             ``trunk`` or ``access``
         """
 
-        mode = request.data.lower()
+        mode = request.get_data().lower()
         if mode == 'trunk':
             switch.set_bond_trunk_mode(bond_number)
         elif mode == 'access':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.9
+Flask>=0.11
 paramiko==1.15.1
 netaddr>=0.7.13
 redlockfifo>=0.0.1


### PR DESCRIPTION
Werkzeug will deprecate the .data attribute in favor of get_data() method.
This closes the issue: https://github.com/internap/netman/issues/142