### PR TITLE
Remove Redlock-FIFO from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Flask>=0.9
 paramiko==1.15.1
 netaddr>=0.7.13
-redlockfifo>=0.0.1
 ncclient==0.4.7
 requests>=2.6.2


### PR DESCRIPTION
This project wasn't used by any code in netman, it's an artifact from
another time.