### PR TITLE
Package Documentation with dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ ChangeLog
 *.egg
 .eggs/
 .venv
-doc_generated/
+netman/api/doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ deploy:
   on:
     tags: true
     repo: internap/netman
+    distributions: "build_sphinx sdist"
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include netman/*
+graft netman/api/doc

--- a/netman/api/netman_api.py
+++ b/netman/api/netman_api.py
@@ -34,9 +34,9 @@ class NetmanApi(object):
 
     def hook_to(self, server):
         self.app = server
-        server.add_url_rule('/netman/info', view_func=self.get_info, methods=['GET'])
-        server.add_url_rule('/netman/apidocs/', view_func=self.api_docs, methods=['GET'])
-        server.add_url_rule('/netman/apidocs/<path:filename>', view_func=self.api_docs, methods=['GET'])
+        server.add_url_rule('/netman/info',endpoint="netman_info",view_func=self.get_info, methods=['GET'])
+        server.add_url_rule('/netman/apidocs/', endpoint="netman_apidocs" ,view_func=self.api_docs, methods=['GET'])
+        server.add_url_rule('/netman/apidocs/<path:filename>', endpoint="netman_apidocs" ,view_func=self.api_docs, methods=['GET'])
 
     @to_response
     def get_info(self):
@@ -65,7 +65,7 @@ class NetmanApi(object):
         Shows this documentation
 
         """
-        return send_from_directory(os.path.dirname(__file__) + "/doc_generated/html/", filename or "index.html")
+        return send_from_directory(os.path.dirname(__file__) + "/doc/html/", filename or "index.html")
 
 
 def _class_fqdn(obj):

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,5 +26,5 @@ logging-level = DEBUG
 
 [build_sphinx]
 all_files = 1
-build-dir = netman/api/doc_generated
+build-dir = netman/api/doc
 source-dir = netman/api/doc_config


### PR DESCRIPTION
This will allow the /netman/apidocs endpoint to be available without
executing 'tox -edocs'. Travis will publish the documentation.