### PR TITLE
Add UnknownInterface exception to compliance tests

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -330,7 +330,7 @@ class Juniper(SwitchBase):
         try:
             self._push(update)
         except RPCError as e:
-            if "port value outside range" in e.message:
+            if "port value outside range" in e.message or "Invalid interface type" in e.message:
                 raise UnknownInterface(interface_id)
             raise
 

--- a/tests/adapters/compliance_tests/reset_interface_test.py
+++ b/tests/adapters/compliance_tests/reset_interface_test.py
@@ -1,5 +1,6 @@
 from hamcrest import assert_that, is_
 
+from netman.core.objects.exceptions import UnknownInterface
 from netman.core.objects.interface_states import ON, OFF
 from netman.core.objects.port_modes import ACCESS
 from tests.adapters.compliance_test_case import ComplianceTestCase
@@ -12,9 +13,13 @@ class ResetInterfaceTest(ComplianceTestCase):
         super(ResetInterfaceTest, self).setUp()
         self.interface_before = self.try_to.get_interface(self.test_port)
 
-    def test_reset_interface_reverts_trunk_vlans(self):
+    def tearDown(self):
+        self.janitor.remove_vlan(90)
+        self.janitor.remove_bond(42)
+        super(ResetInterfaceTest, self).tearDown()
+
+    def test_reverts_trunk_vlans(self):
         self.try_to.add_vlan(90)
-        self.addCleanup(self.janitor.remove_vlan, 90)
 
         self.try_to.set_trunk_mode(self.test_port)
         self.try_to.add_trunk_vlan(self.test_port, 90)
@@ -23,9 +28,8 @@ class ResetInterfaceTest(ComplianceTestCase):
 
         assert_that(self.client.get_interface(self.test_port).trunk_vlans, is_(self.interface_before.trunk_vlans))
 
-    def test_reset_interface_reverts_trunk_native_vlan(self):
+    def test_reverts_trunk_native_vlan(self):
         self.try_to.add_vlan(90)
-        self.addCleanup(self.janitor.remove_vlan, 90)
 
         self.try_to.set_trunk_mode(self.test_port)
         self.try_to.set_interface_native_vlan(self.test_port, 90)
@@ -35,7 +39,7 @@ class ResetInterfaceTest(ComplianceTestCase):
         assert_that(self.client.get_interface(self.test_port).trunk_native_vlan,
                     is_(self.interface_before.trunk_native_vlan))
 
-    def test_reset_interface_reverts_port_mode(self):
+    def test_reverts_port_mode(self):
         if self.interface_before.port_mode == ACCESS:
             self.try_to.set_trunk_mode(self.test_port)
         else:
@@ -45,9 +49,8 @@ class ResetInterfaceTest(ComplianceTestCase):
 
         assert_that(self.try_to.get_interface(self.test_port).port_mode, is_(self.interface_before.port_mode))
 
-    def test_reset_interface_reverts_bond_master(self):
+    def test_reverts_bond_master(self):
         self.try_to.add_bond(42)
-        self.addCleanup(self.janitor.remove_bond, 42)
 
         self.try_to.add_interface_to_bond(self.test_port, 42)
 
@@ -56,7 +59,7 @@ class ResetInterfaceTest(ComplianceTestCase):
         actual_interface = self.try_to.get_interface(self.test_port)
         assert_that(actual_interface.bond_master, is_(self.interface_before.bond_master))
 
-    def test_reset_interface_reverts_port_shutdown(self):
+    def test_reverts_port_shutdown(self):
         if not self.interface_before.shutdown or self.interface_before.shutdown is OFF:
             self.try_to.set_interface_state(self.test_port, ON)
         else:
@@ -66,4 +69,6 @@ class ResetInterfaceTest(ComplianceTestCase):
 
         assert_that(self.client.get_interface(self.test_port).shutdown, is_(self.interface_before.shutdown))
 
-
+    def test_raises_on_unknown_interface(self):
+        with self.assertRaises(UnknownInterface):
+            self.client.reset_interface('nonexistent 2/99')

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -2401,7 +2401,7 @@ class JuniperTest(unittest.TestCase):
 
         assert_that(str(expect.exception), contains_string("Unknown interface ge-0/0/99"))
 
-    def test_reset_interface_with_unknown_rpcerror_raises(self):
+    def test_reset_interface_with_invalid_interface_raises(self):
         self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
             <config>
               <configuration>
@@ -2420,10 +2420,32 @@ class JuniperTest(unittest.TestCase):
             </error-message>
             </rpc-error>"""))))
 
+        with self.assertRaises(UnknownInterface):
+            self.switch.reset_interface("ne-0/0/9")
+
+    def test_reset_interface_with_unknown_rpcerror_raises(self):
+        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
+            <config>
+              <configuration>
+                <interfaces>
+                  <interface operation="replace">
+                    <name>ne-0/0/9</name>
+                  </interface>
+                </interfaces>
+              </configuration>
+            </config>
+        """)).and_raise(RPCError(to_ele(textwrap.dedent("""
+            <rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/11.4R1/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <error-severity>error</error-severity>
+            <error-message>
+            Unknown error
+            </error-message>
+            </rpc-error>"""))))
+
         with self.assertRaises(RPCError) as expect:
             self.switch.reset_interface("ne-0/0/9")
 
-        assert_that(str(expect.exception), contains_string("invalid interface type"))
+        assert_that(str(expect.exception), contains_string("Unknown error"))
 
     def test_unset_interface_access_vlan_removes_the_vlan_members(self):
         self.netconf_mock.should_receive("get_config").with_args(source="candidate", filter=is_xml("""


### PR DESCRIPTION
Ensure all switch raises on unknown interface when
trying to reset it's parameters. Juniper did not supported
this feature in a good manner.

Refactored the reset_interface class to make sure teardown is removed
from test cases.