### PR TITLE
Add UnknownInterface exception to compliance tests

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -331,12 +331,7 @@ class Juniper(SwitchBase):
         update = Update()
         update.add_interface(content)
 
-        try:
-            self._push(update)
-        except RPCError as e:
-            if "port value outside range" in e.message:
-                raise UnknownInterface(interface_id)
-            raise
+        self._push_interface_update(interface_id, update)
 
     def unset_interface_native_vlan(self, interface_id):
         config = self.query(one_interface(interface_id), all_vlans)

--- a/tests/adapters/compliance_tests/reset_interface_test.py
+++ b/tests/adapters/compliance_tests/reset_interface_test.py
@@ -1,5 +1,6 @@
 from hamcrest import assert_that, is_
 
+from netman.core.objects.exceptions import UnknownInterface
 from netman.core.objects.interface_states import ON, OFF
 from netman.core.objects.port_modes import ACCESS
 from tests.adapters.compliance_test_case import ComplianceTestCase
@@ -12,9 +13,13 @@ class ResetInterfaceTest(ComplianceTestCase):
         super(ResetInterfaceTest, self).setUp()
         self.interface_before = self.try_to.get_interface(self.test_port)
 
-    def test_reset_interface_reverts_trunk_vlans(self):
+    def tearDown(self):
+        self.janitor.remove_vlan(90)
+        self.janitor.remove_bond(42)
+        super(ResetInterfaceTest, self).tearDown()
+
+    def test_reverts_trunk_vlans(self):
         self.try_to.add_vlan(90)
-        self.addCleanup(self.janitor.remove_vlan, 90)
 
         self.try_to.set_trunk_mode(self.test_port)
         self.try_to.add_trunk_vlan(self.test_port, 90)
@@ -23,9 +28,8 @@ class ResetInterfaceTest(ComplianceTestCase):
 
         assert_that(self.client.get_interface(self.test_port).trunk_vlans, is_(self.interface_before.trunk_vlans))
 
-    def test_reset_interface_reverts_trunk_native_vlan(self):
+    def test_reverts_trunk_native_vlan(self):
         self.try_to.add_vlan(90)
-        self.addCleanup(self.janitor.remove_vlan, 90)
 
         self.try_to.set_trunk_mode(self.test_port)
         self.try_to.set_interface_native_vlan(self.test_port, 90)
@@ -35,7 +39,7 @@ class ResetInterfaceTest(ComplianceTestCase):
         assert_that(self.client.get_interface(self.test_port).trunk_native_vlan,
                     is_(self.interface_before.trunk_native_vlan))
 
-    def test_reset_interface_reverts_port_mode(self):
+    def test_reverts_port_mode(self):
         if self.interface_before.port_mode == ACCESS:
             self.try_to.set_trunk_mode(self.test_port)
         else:
@@ -45,9 +49,8 @@ class ResetInterfaceTest(ComplianceTestCase):
 
         assert_that(self.try_to.get_interface(self.test_port).port_mode, is_(self.interface_before.port_mode))
 
-    def test_reset_interface_reverts_bond_master(self):
+    def test_reverts_bond_master(self):
         self.try_to.add_bond(42)
-        self.addCleanup(self.janitor.remove_bond, 42)
 
         self.try_to.add_interface_to_bond(self.test_port, 42)
 
@@ -56,7 +59,7 @@ class ResetInterfaceTest(ComplianceTestCase):
         actual_interface = self.try_to.get_interface(self.test_port)
         assert_that(actual_interface.bond_master, is_(self.interface_before.bond_master))
 
-    def test_reset_interface_reverts_port_shutdown(self):
+    def test_reverts_port_shutdown(self):
         if not self.interface_before.shutdown or self.interface_before.shutdown is OFF:
             self.try_to.set_interface_state(self.test_port, ON)
         else:
@@ -66,4 +69,6 @@ class ResetInterfaceTest(ComplianceTestCase):
 
         assert_that(self.client.get_interface(self.test_port).shutdown, is_(self.interface_before.shutdown))
 
-
+    def test_raises_on_unknown_interface(self):
+        with self.assertRaises(UnknownInterface):
+            self.client.reset_interface('nonexistent 2/99')


### PR DESCRIPTION
Ensure all switch raises on unknown interface when
trying to reset it's parameters. Juniper did not supported
this feature in a good manner.

Refactored the reset_interface class to make sure teardown is removed
from test cases.