### PR TITLE
Added reset port for brocade switches

### DIFF
--- a/netman/adapters/switches/brocade.py
+++ b/netman/adapters/switches/brocade.py
@@ -168,7 +168,7 @@ class Brocade(SwitchBase):
         if result and ('Invalid input' in result[0] or 'Error' in result[0]) :
             raise UnknownInterface(interface_id)
 
-        operations = self._get_operations(result)
+        operations = self._get_vlan_association_removal_operations(result)
 
         with self.config():
             if len(operations) > 0:
@@ -218,7 +218,7 @@ class Brocade(SwitchBase):
         if result and 'Invalid input' in result[0]:
             raise UnknownInterface(interface_id)
 
-        operations = self._get_operations(result)
+        operations = self._get_vlan_association_removal_operations(result)
 
         if len(operations) > 0 and not (len(operations) == 1 and operations[0][1] == "untagged"):
             with self.config():
@@ -448,7 +448,7 @@ class Brocade(SwitchBase):
     def _show_vlan(self, vlan_number):
         return self.shell.do("show vlan {}".format(vlan_number))
 
-    def _get_operations(self, result):
+    def _get_vlan_association_removal_operations(self, result):
         operations = []
         for line in result:
             if regex.match("VLAN: (\d*)  ([^\s]*)", line):

--- a/tests/adapters/switches/brocade_backward_compatibility_test.py
+++ b/tests/adapters/switches/brocade_backward_compatibility_test.py
@@ -16,7 +16,7 @@ import unittest
 
 from flexmock import flexmock, flexmock_teardown
 from hamcrest import assert_that, instance_of, is_, equal_to
-from mock import patch, Mock
+from mock import Mock
 from netaddr.ip import IPAddress
 
 from netman.adapters.switches.brocade import Brocade, BackwardCompatibleBrocade
@@ -221,3 +221,13 @@ class BrocadeBackwardCompatibilityTest(unittest.TestCase):
 
         self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                    track_id="1/1", track_decrement=50)
+
+    @ignore_deprecation_warnings
+    def test_reset_interfaces_accepts_no_ethernet(self):
+        self.shell_mock.should_receive("do").with_args("show vlan ethernet 1/4").once().ordered().and_return([])
+
+        self.shell_mock.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("no interface ethernet 1/4").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("exit").once().ordered()
+
+        self.switch.reset_interface("1/4")

--- a/tests/adapters/switches/brocade_test.py
+++ b/tests/adapters/switches/brocade_test.py
@@ -27,7 +27,7 @@ from netman.core.objects.access_groups import IN, OUT
 from netman.core.objects.exceptions import IPNotAvailable, UnknownVlan, UnknownIP, UnknownAccessGroup, BadVlanNumber, \
     BadVlanName, UnknownInterface, TrunkVlanNotSet, UnknownVrf, VlanVrfNotSet, VrrpAlreadyExistsForVlan, BadVrrpPriorityNumber, BadVrrpGroupNumber, \
     BadVrrpTimers, BadVrrpTracking, NoIpOnVlanForVrrp, VrrpDoesNotExistForVlan, UnknownDhcpRelayServer, DhcpRelayServerAlreadyExists, \
-    VlanAlreadyExist, InvalidAccessGroupName
+    VlanAlreadyExist, InvalidAccessGroupName, InvalidValue
 from netman.core.objects.interface_states import OFF, ON
 from netman.core.objects.port_modes import ACCESS, TRUNK
 from netman.core.objects.switch_descriptor import SwitchDescriptor
@@ -584,6 +584,53 @@ class BrocadeTest(unittest.TestCase):
             self.switch.set_access_vlan("ethernet 9/999", vlan=2999)
 
         assert_that(str(expect.exception), equal_to("Unknown interface ethernet 9/999"))
+
+    def test_reset_interfaces_works(self):
+        self.shell_mock.should_receive("do").with_args("show vlan ethernet 1/4").once().ordered().and_return([])
+
+        self.shell_mock.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("no interface ethernet 1/4").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("exit").once().ordered()
+
+        self.switch.reset_interface("ethernet 1/4")
+
+    def test_reset_interfaces_on_invalid_input_raises_unknown_interface(self):
+        self.shell_mock.should_receive("do").with_args("show vlan ethernet 9/999").once().ordered().and_return([
+            'Invalid input -> 9/999',
+            'Type ? for a list'])
+
+        with self.assertRaises(UnknownInterface):
+            self.switch.reset_interface("ethernet 9/999")
+
+    def test_reset_interfaces_on_invalid_interface_raises_unknown_interface(self):
+        self.shell_mock.should_receive("do").with_args("show vlan ethernet 1/64").once().ordered().and_return([
+            'Error - invalid interface 1/64'])
+
+        with self.assertRaises(UnknownInterface):
+            self.switch.reset_interface("ethernet 1/64")
+
+    def test_reset_interfaces_on_invalid_slot_raises_unknown_interface(self):
+        self.shell_mock.should_receive("do").with_args("show vlan ethernet 2/1").once().ordered().and_return([
+            'Error - interface 2/1 is not an ETHERNET interface'])
+
+        with self.assertRaises(UnknownInterface):
+            self.switch.reset_interface("ethernet 2/1")
+
+    def test_reset_interfaces_cleans_tagged_vlans(self):
+        self.shell_mock.should_receive("do").with_args("show vlan ethernet 1/4").and_return(['VLAN: 1200  Untagged',
+                                                                                             'VLAN: 1201  Tagged'])
+
+        self.shell_mock.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("vlan 1200").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("no untagged ethernet 1/4").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("vlan 1201").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("no tagged ethernet 1/4").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("exit").and_return([]).once().ordered()
+
+        self.shell_mock.should_receive("do").with_args("no interface ethernet 1/4").once().ordered().and_return([])
+        self.shell_mock.should_receive("do").with_args("exit").and_return([]).once().ordered()
+
+        self.switch.reset_interface("ethernet 1/4")
 
     def test_unset_interface_access_vlan(self):
         self.shell_mock.should_receive("do").with_args("show vlan brief | include ethe 1/4").once().ordered().and_return([


### PR DESCRIPTION
Brocade switches can have their port resetted by netman.
This change also allows for port naming without stating
ethernet.
Also bumped fake-switches version and address issue with non
routable ips in connectivity test.

Added reset port for brocade switches

Brocade switches can have their port resetted by netman.
This change also allows for port naming without stating
ethernet.

Bump fake-switch version to fix port naming regression