### PR TITLE
Use operation="delete" on reset_interface

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -328,7 +328,7 @@ class Juniper(SwitchBase):
 
     def reset_interface(self, interface_id):
         content = to_ele("""
-            <interface operation=\"replace\">
+            <interface operation=\"delete\">
                 <name>{0}</name>
             </interface>
         """.format(interface_id))

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -2777,7 +2777,7 @@ class JuniperTest(unittest.TestCase):
             <config>
               <configuration>
                 <interfaces>
-                  <interface operation="replace">
+                  <interface operation="delete">
                     <name>ge-0/0/6</name>
                   </interface>
                 </interfaces>
@@ -2792,7 +2792,7 @@ class JuniperTest(unittest.TestCase):
             <config>
               <configuration>
                 <interfaces>
-                  <interface operation="replace">
+                  <interface operation="delete">
                     <name>ge-0/0/99</name>
                   </interface>
                 </interfaces>
@@ -2816,7 +2816,7 @@ class JuniperTest(unittest.TestCase):
             <config>
               <configuration>
                 <interfaces>
-                  <interface operation="replace">
+                  <interface operation="delete">
                     <name>ne-0/0/9</name>
                   </interface>
                 </interfaces>
@@ -2838,7 +2838,7 @@ class JuniperTest(unittest.TestCase):
             <config>
               <configuration>
                 <interfaces>
-                  <interface operation="replace">
+                  <interface operation="delete">
                     <name>ne-0/0/9</name>
                   </interface>
                 </interfaces>


### PR DESCRIPTION
Operation="replace" is not the suggested way to reset an interface.
Operation="delete" has the same behavior that replace, this is the
one that is supposed to be used.