### PR TITLE
Cisco interface reset

### DIFF
--- a/netman/adapters/switches/cisco.py
+++ b/netman/adapters/switches/cisco.py
@@ -415,6 +415,12 @@ class Cisco(SwitchBase):
             else:
                 self.ssh.do('no ip redirects')
 
+    def reset_interface(self, interface_id):
+        with self.config():
+            for line in self.ssh.do('default interface {}'.format(interface_id)):
+                if 'Invalid input detected' in line:
+                    raise UnknownInterface(interface_id)
+
     def get_versions(self):
         result = self.ssh.do('show version')
 

--- a/tests/adapters/switches/cisco_test.py
+++ b/tests/adapters/switches/cisco_test.py
@@ -2514,3 +2514,27 @@ class CiscoTest(unittest.TestCase):
             "CLEI Code Number": "COMB600BRA",
             "Hardware Board Revision Number": "0x09",            
         }))
+
+    def test_reset_interface(self):
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([
+            "Enter configuration commands, one per line.  End with CNTL/Z."
+        ])
+        self.mocked_ssh_client.should_receive("do").with_args("default interface FastEthernet0/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).once().ordered()
+
+        self.switch.reset_interface("FastEthernet0/4")
+
+    def test_reset_interface_unknown_interface_name_raises(self):
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([
+            "Enter configuration commands, one per line.  End with CNTL/Z."
+        ])
+        self.mocked_ssh_client.should_receive("do").with_args("default interface WrongInterfaceName0/4").and_return([
+            "         ^"
+            "% Invalid input detected at '^' marker."
+        ]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).once().ordered()
+
+        with self.assertRaises(UnknownInterface) as expect:
+            self.switch.reset_interface("WrongInterfaceName0/4")
+
+        assert_that(str(expect.exception), equal_to("Unknown interface WrongInterfaceName0/4"))


### PR DESCRIPTION
This re-enables PR-147 that was rollbacked and enable cisco reset-interface.