### PR TITLE
Un-pin ncclient version

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -56,8 +56,6 @@ class Juniper(SwitchBase):
 
         self.netconf = manager.connect(**params)
 
-        _monkey_patch_issue_125(self.netconf)
-
     def _disconnect(self):
         try:
             self.netconf.close_session()
@@ -1181,65 +1179,3 @@ class _PhysicalInterface(object):
     def to_interface(self):
         return Interface(name=self.name, shutdown=self.shutdown, port_mode=ACCESS)
 
-
-def _monkey_patch_issue_125(netconf_client):
-    """
-    This is patching ncclient 0.4.7 until this is merged and released on pipy
-    https://github.com/ncclient/ncclient/pull/120
-    """
-
-    import os
-    import types
-    from cStringIO import StringIO
-
-    from ncclient.transport.ssh import logger, MSG_DELIM
-
-    def _parse10(self):
-
-        """Messages are delimited by MSG_DELIM. The buffer could have grown by
-        a maximum of BUF_SIZE bytes everytime this method is called. Retains
-        state across method calls and if a byte has been read it will not be
-        considered again."""
-
-        logger.debug("parsing netconf v1.0")
-        delim = MSG_DELIM
-        n = len(delim)
-        expect = self._parsing_state10
-        buf = self._buffer
-        buf.seek(self._parsing_pos10)
-        while True:
-            x = buf.read(1)
-            if not x: # done reading
-                break
-            elif x == delim[expect]: # what we expected
-                expect += 1 # expect the next delim char
-            else:
-                expect = 0
-                continue
-            # loop till last delim char expected, break if other char encountered
-            for i in range(expect, n):
-                x = buf.read(1)
-                if not x: # done reading
-                    break
-                if x == delim[expect]: # what we expected
-                    expect += 1 # expect the next delim char
-                else:
-                    expect = 0 # reset
-                    break
-            else: # if we didn't break out of the loop, full delim was parsed
-                msg_till = buf.tell() - n
-                buf.seek(0)
-                logger.debug('parsed new message')
-                self._dispatch_message(buf.read(msg_till).strip())
-                buf.seek(n, os.SEEK_CUR)
-                rest = buf.read()
-                buf = StringIO()
-                buf.write(rest)
-                buf.seek(0)
-                expect = 0
-        self._buffer = buf
-        self._parsing_state10 = expect
-        self._parsing_pos10 = self._buffer.tell()
-
-
-    netconf_client._session._parse10 = types.MethodType(_parse10, netconf_client._session)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.11
 paramiko==1.15.1
 netaddr>=0.7.13
-ncclient==0.4.7
+ncclient>=0.5.0
 requests>=2.6.2


### PR DESCRIPTION
This removes the monkeypatched ncclient classes and use the lastest
ncclient because our improvement has been merged and tagged in ncclient
0.5.0.

This PR closes #125