### PR TITLE
Fix the parsing of get information command that has new lines

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -726,7 +726,8 @@ class Juniper(SwitchBase):
             </get-interface-information>
         """))
 
-        return [_PhysicalInterface(i.xpath("name")[0].text, shutdown=i.xpath("admin-status")[0].text == "down")
+        return [_PhysicalInterface(i.xpath("name")[0].text.strip(),
+                                   shutdown=i.xpath("admin-status")[0].text.strip() == "down")
                 for i in terse.xpath("interface-information/physical-interface")]
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 flexmock>=0.10.2
-fake-switches>=1.1.0
+fake-switches>=1.1.2
 MockSSH>=1.4.2
 Sphinx
 sphinxcontrib-httpdomain

--- a/tests/adapters/switches/juniper_qfx_copper_test.py
+++ b/tests/adapters/switches/juniper_qfx_copper_test.py
@@ -133,9 +133,15 @@ class JuniperTest(unittest.TestCase):
                 """)).and_return(an_rpc_response(textwrap.dedent("""
                     <interface-information style="terse">
                       <physical-interface>
-                        <name>ge-0/0/1</name>
-                        <admin-status>down</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/1
+                    </name>
+                        <admin-status>
+                    down
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                       </physical-interface>
                     </interface-information>
                 """)))
@@ -155,69 +161,131 @@ class JuniperTest(unittest.TestCase):
                 """)).and_return(an_rpc_response(textwrap.dedent("""
                     <interface-information style="terse">
                       <physical-interface>
-                        <name>ge-0/0/1</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/1
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                         <logical-interface>
-                          <name>ge-0/0/1.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/1.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/2</name>
-                        <admin-status>down</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/2
+                    </name>
+                        <admin-status>
+                    down
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                         <logical-interface>
-                          <name>ge-0/0/2.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/2.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/3</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/3
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                         <logical-interface>
-                          <name>ge-0/0/3.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/3.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/4</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/4
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                         <logical-interface>
-                          <name>ge-0/0/4.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/4.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/5</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/5
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                       </physical-interface>
                     </interface-information>
                 """)))

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -849,9 +849,15 @@ class JuniperTest(unittest.TestCase):
                 """)).and_return(an_rpc_response(textwrap.dedent("""
                     <interface-information style="terse">
                       <physical-interface>
-                        <name>ge-0/0/27</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/27
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                       </physical-interface>
                     </interface-information>
                 """)))
@@ -889,9 +895,15 @@ class JuniperTest(unittest.TestCase):
                 """)).and_return(an_rpc_response(textwrap.dedent("""
                     <interface-information style="terse">
                       <physical-interface>
-                        <name>ge-0/0/27</name>
-                        <admin-status>down</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/27
+                    </name>
+                        <admin-status>
+                    down
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                       </physical-interface>
                     </interface-information>
                 """)))
@@ -922,9 +934,15 @@ class JuniperTest(unittest.TestCase):
                 """)).and_return(an_rpc_response(textwrap.dedent("""
                     <interface-information style="terse">
                       <physical-interface>
-                        <name>ge-0/0/1</name>
-                        <admin-status>down</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/1
+                    </name>
+                        <admin-status>
+                    down
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                       </physical-interface>
                     </interface-information>
                 """)))
@@ -944,69 +962,127 @@ class JuniperTest(unittest.TestCase):
                 """)).and_return(an_rpc_response(textwrap.dedent("""
                     <interface-information style="terse">
                       <physical-interface>
-                        <name>ge-0/0/1</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/1
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                         <logical-interface>
-                          <name>ge-0/0/1.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/1.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/2</name>
-                        <admin-status>down</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/2
+                    </name>
+                        <admin-status>
+                    down
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                         <logical-interface>
-                          <name>ge-0/0/2.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/2.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/3</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/3
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                         <logical-interface>
-                          <name>ge-0/0/3.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/3.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/4</name>
+                        <name>
+                    ge-0/0/4
+                    </name>
                         <admin-status>up</admin-status>
                         <oper-status>down</oper-status>
                         <logical-interface>
-                          <name>ge-0/0/4.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/4.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/5</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/5
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                       </physical-interface>
                     </interface-information>
                 """)))
@@ -1148,14 +1224,26 @@ class JuniperTest(unittest.TestCase):
                 """)).and_return(an_rpc_response(textwrap.dedent("""
                     <interface-information style="terse">
                       <physical-interface>
-                        <name>ge-0/0/1</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/1
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                       </physical-interface>
                       <physical-interface>
-                        <name>ge-0/0/2</name>
-                        <admin-status>down</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/2
+                    </name>
+                        <admin-status>
+                    down
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                       </physical-interface>
                     </interface-information>
                 """)))
@@ -1194,17 +1282,31 @@ class JuniperTest(unittest.TestCase):
                 """)).and_return(an_rpc_response(textwrap.dedent("""
                     <interface-information style="terse">
                       <physical-interface>
-                        <name>ge-0/0/1</name>
-                        <admin-status>up</admin-status>
-                        <oper-status>down</oper-status>
+                        <name>
+                    ge-0/0/1
+                    </name>
+                        <admin-status>
+                    up
+                    </admin-status>
+                        <oper-status>
+                    down
+                    </oper-status>
                         <logical-interface>
-                          <name>ge-0/0/1.0</name>
-                          <admin-status>up</admin-status>
-                          <oper-status>down</oper-status>
+                          <name>
+                    ge-0/0/1.0
+                    </name>
+                          <admin-status>
+                    up
+                    </admin-status>
+                          <oper-status>
+                    down
+                    </oper-status>
                           <filter-information>
                           </filter-information>
                           <address-family>
-                            <address-family-name>eth-switch</address-family-name>
+                            <address-family-name>
+                    eth-switch
+                    </address-family-name>
                           </address-family>
                         </logical-interface>
                       </physical-interface>
@@ -5317,9 +5419,15 @@ class JuniperTest(unittest.TestCase):
         """)).and_return(an_rpc_response(textwrap.dedent("""
             <interface-information style="terse">
               <physical-interface>
-                <name>ge-0/0/1</name>
-                <admin-status>up</admin-status>
-                <oper-status>down</oper-status>
+                <name>
+            ge-0/0/1
+            </name>
+                <admin-status>
+            up
+            </admin-status>
+                <oper-status>
+            down
+            </oper-status>
               </physical-interface>
             </interface-information>
         """)))
@@ -5356,9 +5464,15 @@ class JuniperTest(unittest.TestCase):
         """)).and_return(an_rpc_response(textwrap.dedent("""
             <interface-information style="terse">
               <physical-interface>
-                <name>ge-0/0/1</name>
-                <admin-status>up</admin-status>
-                <oper-status>down</oper-status>
+                <name>
+            ge-0/0/1
+            </name>
+                <admin-status>
+            up
+            </admin-status>
+                <oper-status>
+            down
+            </oper-status>
               </physical-interface>
             </interface-information>
         """)))


### PR DESCRIPTION
The switch returns all values surrounded by new lines, not stripping
creates wierd behavior as interfaces name would not match the names
in the configuration giving /interfaces calls only empty interfaces
with 2 new lines in their names

Fixes #161