### PR TITLE
Add auto-negotiation information on get_interface

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -669,6 +669,10 @@ class Juniper(SwitchBase):
                 interface.trunk_vlans = vlans
             interface.trunk_native_vlan = value_of(self.custom_strategies.get_interface_trunk_native_vlan_id_node(interface_node), transformer=int)
             interface.shutdown = first(interface_node.xpath("disable")) is not None
+            if first(interface_node.xpath('ether-options/auto-negotiation')) is not None:
+                interface.auto_negotiation = True
+            elif first(interface_node.xpath('ether-options/no-auto-negotiation')) is not None:
+                interface.auto_negotiation = False
         return interface
 
     def node_to_interface(self, interface_node, config):

--- a/netman/core/objects/interface.py
+++ b/netman/core/objects/interface.py
@@ -16,7 +16,7 @@ from netman.core.objects import Model
 
 
 class BaseInterface(Model):
-    def __init__(self,  shutdown=None, port_mode=None,
+    def __init__(self, shutdown=None, port_mode=None,
                  access_vlan=None, trunk_native_vlan=None, trunk_vlans=None):
         self.shutdown = shutdown
         self.port_mode = port_mode
@@ -26,7 +26,8 @@ class BaseInterface(Model):
 
 
 class Interface(BaseInterface):
-    def __init__(self, name=None, bond_master=None, **interface):
+    def __init__(self, name=None, bond_master=None, auto_negotiation=None, **interface):
         super(Interface, self).__init__(**interface)
         self.name = name
         self.bond_master = bond_master
+        self.auto_negotiation = auto_negotiation

--- a/tests/adapters/switches/juniper_qfx_copper_test.py
+++ b/tests/adapters/switches/juniper_qfx_copper_test.py
@@ -108,6 +108,7 @@ class JuniperTest(unittest.TestCase):
         assert_that(if1.access_vlan, equal_to(None))
         assert_that(if1.trunk_native_vlan, equal_to(None))
         assert_that(if1.trunk_vlans, equal_to([]))
+        assert_that(if1.auto_negotiation, equal_to(None))
 
     def test_get_nonexistent_interface_raises(self):
         self.switch.in_transaction = False
@@ -342,6 +343,9 @@ class JuniperTest(unittest.TestCase):
               </interface>
               <interface>
                 <name>ge-0/0/4</name>
+                <ether-options>
+                  <no-auto-negotiation/>
+                </ether-options>
                 <unit>
                   <name>0</name>
                   <family>
@@ -393,6 +397,7 @@ class JuniperTest(unittest.TestCase):
         assert_that(if1.access_vlan, equal_to(None))
         assert_that(if1.trunk_native_vlan, equal_to(None))
         assert_that(if1.trunk_vlans, equal_to([]))
+        assert_that(if1.auto_negotiation, equal_to(None))
 
         assert_that(if2.name, equal_to("ge-0/0/2"))
         assert_that(if2.shutdown, equal_to(True))
@@ -410,10 +415,12 @@ class JuniperTest(unittest.TestCase):
         assert_that(if4.name, equal_to("ge-0/0/4"))
         assert_that(if4.trunk_native_vlan, equal_to(None))
         assert_that(if4.trunk_vlans, equal_to([]))
+        assert_that(if4.auto_negotiation, equal_to(False))
 
         assert_that(if5.name, equal_to("ge-0/0/5"))
         assert_that(if5.port_mode, equal_to(BOND_MEMBER))
         assert_that(if5.bond_master, equal_to(10))
+        assert_that(if5.auto_negotiation, equal_to(True))
 
     def test_get_interface_with_trunk_native_vlan_at_root(self):
         self.switch.in_transaction = False

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -824,6 +824,7 @@ class JuniperTest(unittest.TestCase):
         assert_that(interface.access_vlan, equal_to(None))
         assert_that(interface.trunk_native_vlan, equal_to(None))
         assert_that(interface.trunk_vlans, equal_to([]))
+        assert_that(interface.auto_negotiation, equal_to(None))
 
     def test_get_unconfigured_but_existing_interface_returns_an_empty_interface(self):
         self.switch.in_transaction = False
@@ -1123,6 +1124,9 @@ class JuniperTest(unittest.TestCase):
               </interface>
               <interface>
                 <name>ge-0/0/3</name>
+                <ether-options>
+                  <no-auto-negotiation/>
+                </ether-options>
                 <unit>
                   <name>0</name>
                   <family>
@@ -1139,6 +1143,9 @@ class JuniperTest(unittest.TestCase):
               </interface>
               <interface>
                 <name>ge-0/0/4</name>
+                <ether-options>
+                  <auto-negotiation/>
+                </ether-options>
                 <unit>
                   <name>0</name>
                   <family>
@@ -1192,6 +1199,7 @@ class JuniperTest(unittest.TestCase):
         assert_that(if1.access_vlan, equal_to(None))
         assert_that(if1.trunk_native_vlan, equal_to(None))
         assert_that(if1.trunk_vlans, equal_to([]))
+        assert_that(if1.auto_negotiation, equal_to(None))
 
         assert_that(if2.name, equal_to("ge-0/0/2"))
         assert_that(if2.shutdown, equal_to(True))
@@ -1205,10 +1213,12 @@ class JuniperTest(unittest.TestCase):
         assert_that(if3.access_vlan, equal_to(None))
         assert_that(if3.trunk_native_vlan, equal_to(2000))
         assert_that(if3.trunk_vlans, equal_to([999, 1000, 1001]))
+        assert_that(if3.auto_negotiation, equal_to(False))
 
         assert_that(if4.name, equal_to("ge-0/0/4"))
         assert_that(if4.trunk_native_vlan, equal_to(None))
         assert_that(if4.trunk_vlans, equal_to([]))
+        assert_that(if4.auto_negotiation, equal_to(True))
 
         assert_that(if5.name, equal_to("ge-0/0/5"))
         assert_that(if5.port_mode, equal_to(BOND_MEMBER))


### PR DESCRIPTION
Exposes a way to know if auto-negociation is enabled on the port or
if it's disabled for juniper and juniper QFX copper switch.

Juniper QFX doesn't have auto-negociation enabled by default and on
other switches it's a default.