### PR TITLE
Add juniper set_interface_auto_negotiation_state

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -324,6 +324,21 @@ class Juniper(SwitchBase):
                     raise UnknownVlan(vlan)
                 raise
 
+    def set_interface_auto_negotiation_state(self, interface_id, negotiation_state):
+        content = to_ele("""
+            <interface>
+                <name>{0}</name>
+            </interface>
+            """.format(interface_id))
+        if negotiation_state == ON:
+            content.append(to_ele("<ether-options><auto-negotiation></ether-options>"))
+        else:
+            content.append(to_ele("<ether-options><no-auto-negotiation></ether-options>"))
+        update = Update()
+        update.add_interface(content)
+
+        self._push_interface_update(interface_id, update)
+
     def unset_interface_auto_negotiation_state(self, interface_id):
         config = self.query(one_interface(interface_id))
         interface_node = self.get_interface_config(interface_id, config)

--- a/netman/core/objects/switch_base.py
+++ b/netman/core/objects/switch_base.py
@@ -83,6 +83,9 @@ class SwitchOperations(BackwardCompatibleSwitchOperations):
     def unset_interface_state(self, interface_id):
         raise NotImplementedError()
 
+    def set_interface_auto_negotiation_state(self, interface_id, negotiation_state):
+        raise NotImplementedError()
+
     def unset_interface_auto_negotiation_state(self, interface_id):
         raise NotImplementedError()
 

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -3622,6 +3622,61 @@ class JuniperTest(unittest.TestCase):
         with self.assertRaises(NativeVlanNotSet):
             self.switch.unset_interface_native_vlan("ge-0/0/6")
 
+    def test_set_interface_auto_negotiation_state_ON_works(self):
+        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
+                <config>
+                  <configuration>
+                    <interfaces>
+                      <interface>
+                        <name>ge-0/0/6</name>
+                        <ether-options>
+                          <auto-negotiation/>
+                        </ether-options>
+                      </interface>
+                    </interfaces>
+                  </configuration>
+                </config>
+            """)).and_return(an_ok_response())
+
+        self.switch.set_interface_auto_negotiation_state("ge-0/0/6", ON)
+
+    def test_set_interface_auto_negotiation_state_OFF_works(self):
+        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
+                <config>
+                  <configuration>
+                    <interfaces>
+                      <interface>
+                        <name>ge-0/0/6</name>
+                        <ether-options>
+                          <no-auto-negotiation/>
+                        </ether-options>
+                      </interface>
+                    </interfaces>
+                  </configuration>
+                </config>
+            """)).and_return(an_ok_response())
+
+        self.switch.set_interface_auto_negotiation_state("ge-0/0/6", OFF)
+
+    def test_set_interface_auto_negotiation_raises_on_unknown_interface(self):
+        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
+                <config>
+                  <configuration>
+                    <interfaces>
+                      <interface>
+                        <name>ge-0/0/128</name>
+                        <ether-options>
+                          <no-auto-negotiation/>
+                        </ether-options>
+                      </interface>
+                    </interfaces>
+                  </configuration>
+                </config>
+            """)).and_raise(a_port_value_outside_range_rpc_error())
+
+        with self.assertRaises(UnknownInterface):
+            self.switch.set_interface_auto_negotiation_state("ge-0/0/128", OFF)
+
     def test_unset_interface_auto_negotiation_state_works_when_enabled(self):
         self.netconf_mock.should_receive("get_config").with_args(source="candidate", filter=is_xml("""
                 <filter>


### PR DESCRIPTION
This allow to set the auto-negotiation mode on the juniper switch.
Juniper QFX switches with no auto-negotiation on the port will not be
able to communicate with equipement, therefore we need to add this
method.