### PR TITLE
Add unset-interface-auto-negotiation

### DIFF
--- a/netman/core/objects/switch_base.py
+++ b/netman/core/objects/switch_base.py
@@ -83,6 +83,9 @@ class SwitchOperations(BackwardCompatibleSwitchOperations):
     def unset_interface_state(self, interface_id):
         raise NotImplementedError()
 
+    def unset_interface_auto_negotiation_state(self, interface_id):
+        raise NotImplementedError()
+
     def set_interface_native_vlan(self, interface_id, vlan):
         raise NotImplementedError()
 


### PR DESCRIPTION
This allows to remove a custom configuration that has been configured on
a port. This method will remove auto-negotiation configuration but will
not modify port speed or duplex.