### PR TITLE
Add the compliance tests for auto-negotiation

### DIFF
--- a/netman/adapters/switches/cached.py
+++ b/netman/adapters/switches/cached.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 
 from netman.core.objects.bond import Bond
 from netman.core.objects.interface import Interface
-from netman.core.objects.interface_states import OFF
+from netman.core.objects.interface_states import OFF, ON
 from netman.core.objects.port_modes import ACCESS, TRUNK
 from netman.core.objects.switch_base import SwitchBase
 from netman.core.objects.vlan import Vlan
@@ -299,6 +299,14 @@ class CachedSwitch(SwitchBase):
     def unset_interface_state(self, interface_id):
         self.real_switch.unset_interface_state(interface_id)
         self.interfaces_cache.refresh_items.add(interface_id)
+
+    def set_interface_auto_negotiation_state(self, interface_id, state):
+        self.real_switch.set_interface_auto_negotiation_state(interface_id, state)
+        self.interfaces_cache[interface_id].auto_negotiation = (state == ON)
+
+    def unset_interface_auto_negotiation_state(self, interface_id):
+        self.real_switch.unset_interface_auto_negotiation_state(interface_id)
+        self.interfaces_cache[interface_id].auto_negotiation = None
 
     def add_bond(self, number):
         self.real_switch.add_bond(number)

--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -634,7 +634,7 @@ class Juniper(SwitchBase):
             self._push(configuration)
         except RPCError as e:
             if "port value outside range" in e.message \
-                    or "Invalid interface type" in e.message \
+                    or "invalid interface type" in e.message \
                     or "device value outside range" in e.message:
                 raise UnknownInterface(interface_id)
             raise

--- a/netman/adapters/switches/remote.py
+++ b/netman/adapters/switches/remote.py
@@ -239,6 +239,12 @@ class RemoteSwitch(SwitchBase):
     def unset_interface_state(self, interface_id):
         self.delete("/interfaces/" + interface_id + '/shutdown')
 
+    def set_interface_auto_negotiation_state(self, interface_id, state):
+        self.put("/interfaces/" + interface_id + '/auto-negotiation', raw_data='true' if state is ON else 'false')
+
+    def unset_interface_auto_negotiation_state(self, interface_id):
+        self.delete("/interfaces/" + interface_id + '/auto-negotiation')
+
     def add_bond(self, number):
         self.post("/bonds", data={'number': number})
 

--- a/netman/api/doc_config/api_samples/get_switch_hostname_bond_v1.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_bond_v1.json
@@ -9,6 +9,7 @@
     "port_mode": "access",
     "access_vlan": 1999,
     "trunk_native_vlan": null,
-    "trunk_vlans": []
+    "trunk_vlans": [],
+    "auto_negotiation": null
   }
 }

--- a/netman/api/doc_config/api_samples/get_switch_hostname_bonds_v1.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_bonds_v1.json
@@ -10,7 +10,8 @@
       "port_mode": "access",
       "access_vlan": 1999,
       "trunk_native_vlan": null,
-      "trunk_vlans": []
+      "trunk_vlans": [],
+      "auto_negotiation": null
     }
   },
   {
@@ -31,7 +32,8 @@
         3000,
         3001,
         3002
-      ]
+      ],
+      "auto_negotiation": null
     }
   },
   {
@@ -49,7 +51,8 @@
         3000,
         3001,
         3002
-      ]
+      ],
+      "auto_negotiation": null
     }
   }
 ]

--- a/netman/api/doc_config/api_samples/get_switch_hostname_interface.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_interface.json
@@ -5,5 +5,6 @@
    "port_mode": "trunk",
    "access_vlan": null,
    "trunk_native_vlan": 2999,
-   "trunk_vlans": [3000, 3001, 3002]
+   "trunk_vlans": [3000, 3001, 3002],
+   "auto_negotiation": null
 }

--- a/netman/api/doc_config/api_samples/get_switch_hostname_interfaces.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_interfaces.json
@@ -6,7 +6,8 @@
       "port_mode": "trunk",
       "access_vlan": null,
       "trunk_native_vlan": 2999,
-      "trunk_vlans": [3000, 3001, 3002]
+      "trunk_vlans": [3000, 3001, 3002],
+      "auto_negotiation": null
    },
    {
       "name": "FastEthernet0/3",
@@ -15,7 +16,8 @@
       "port_mode": "access",
       "access_vlan": 1999,
       "trunk_native_vlan": null,
-      "trunk_vlans": []
+      "trunk_vlans": [],
+      "auto_negotiation": null
    },
    {
       "name": "GigabitEthernet0/6",
@@ -24,7 +26,8 @@
       "port_mode": "dynamic",
       "access_vlan": 1999,
       "trunk_native_vlan": 2999,
-      "trunk_vlans": [3000, 3001, 3002]
+      "trunk_vlans": [3000, 3001, 3002],
+      "auto_negotiation": true
    },
    {
       "name": "GigabitEthernet0/8",
@@ -33,6 +36,7 @@
       "port_mode": "bond_member",
       "access_vlan": null,
       "trunk_native_vlan": null,
-      "trunk_vlans": []
+      "trunk_vlans": [],
+      "auto_negotiation": false
    }
 ]

--- a/netman/api/objects/interface.py
+++ b/netman/api/objects/interface.py
@@ -28,11 +28,12 @@ class V1(Serializer):
             base_interface.to_api(interface),
             name=interface.name,
             bond_master=interface.bond_master,
+            auto_negotiation=interface.auto_negotiation
         )
 
     def to_core(self, serialized):
         params = dict(vars(base_interface.to_core(serialized)))
-        params.update(sub_dict(serialized, 'name', 'bond_master'))
+        params.update(sub_dict(serialized, 'name', 'bond_master', 'auto_negotiation'))
         return Interface(**params)
 
 

--- a/netman/api/switch_api.py
+++ b/netman/api/switch_api.py
@@ -62,6 +62,8 @@ class SwitchApi(SwitchApiBase):
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/description', view_func=self.unset_interface_description, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/spanning-tree', view_func=self.edit_interface_spanning_tree, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/lldp', view_func=self.set_interface_lldp_state, methods=['PUT'])
+        server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/auto-negotiation', view_func=self.set_interface_auto_negotiation_state, methods=['PUT'])
+        server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/auto-negotiation', view_func=self.unset_interface_auto_negotiation_state, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/bonds', view_func=self.get_bonds, methods=['GET'])
         server.add_url_rule('/switches/<hostname>/bonds', view_func=self.add_bond, methods=['POST'])
         server.add_url_rule('/switches/<hostname>/bonds/<bond_number>', view_func=self.get_bond, methods=['GET'])
@@ -361,13 +363,43 @@ class SwitchApi(SwitchApiBase):
     @resource(Switch, Interface)
     def unset_shutdown_state(self, switch, interface_id):
         """
-        Sets the shutdown state of an interface
+        Unsets the shutdown state of an interface
 
         :arg str hostname: Hostname or IP of the switch
         :arg str interface_id: Interface name (ex. ``FastEthernet0/1``, ``ethernet1/11``)
         """
 
         switch.unset_interface_state(interface_id)
+        return 204, None
+
+    @to_response
+    @content(is_boolean)
+    @resource(Switch, Interface)
+    def set_interface_auto_negotiation_state(self, switch, interface_id, state):
+        """
+        Sets the auto_negotiation state of an interface
+
+        :arg str hostname: Hostname or IP of the switch
+        :arg str interface_id: Interface name (ex. ``FastEthernet0/1``, ``ethernet1/11``)
+        :body:
+            ``true`` or ``false``
+        """
+
+        switch.set_interface_auto_negotiation_state(interface_id, ON if state is True else OFF)
+
+        return 204, None
+
+    @to_response
+    @resource(Switch, Interface)
+    def unset_interface_auto_negotiation_state(self, switch, interface_id):
+        """
+        Unsets the auto-negotiation state of an interface
+
+        :arg str hostname: Hostname or IP of the switch
+        :arg str interface_id: Interface name (ex. ``FastEthernet0/1``, ``ethernet1/11``)
+        """
+
+        switch.unset_interface_auto_negotiation_state(interface_id)
         return 204, None
 
     @to_response

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 flexmock>=0.10.2
-fake-switches>=1.1.2
+fake-switches>=1.1.4
 MockSSH>=1.4.2
 Sphinx
 sphinxcontrib-httpdomain

--- a/tests/adapters/compliance_tests/get_interface_test.py
+++ b/tests/adapters/compliance_tests/get_interface_test.py
@@ -39,6 +39,7 @@ class GetInterfaceTest(ComplianceTestCase):
         self.try_to.set_trunk_mode(expected.name)
         self.try_to.set_interface_state(expected.name, ON)
         self.try_to.set_interface_native_vlan(expected.name, 2000)
+        self.try_to.set_interface_auto_negotiation_state(expected.name, ON)
 
         interface_from_single = self.client.get_interface(expected.name)
         interfaces = [inte for inte in self.client.get_interfaces() if inte.name == expected.name]
@@ -49,6 +50,7 @@ class GetInterfaceTest(ComplianceTestCase):
         assert_that(interface_from_single.shutdown, is_(interface_from_multiple.shutdown))
         assert_that(interface_from_single.trunk_native_vlan, is_(interface_from_multiple.trunk_native_vlan))
         assert_that(interface_from_single.trunk_vlans, is_(interface_from_multiple.trunk_vlans))
+        assert_that(interface_from_single.auto_negotiation, is_(interface_from_multiple.auto_negotiation))
 
     def test_getinterface_nonexistent_raises(self):
         with self.assertRaises(UnknownInterface)as expect:

--- a/tests/adapters/compliance_tests/set_interface_auto_negotiation_state_test.py
+++ b/tests/adapters/compliance_tests/set_interface_auto_negotiation_state_test.py
@@ -1,0 +1,47 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from hamcrest import assert_that, is_
+
+from netman.core.objects.exceptions import UnknownInterface
+from netman.core.objects.interface_states import ON, OFF
+from tests import has_message
+from tests.adapters.compliance_test_case import ComplianceTestCase
+
+
+class SetInterfaceAutoNegotiationStateTest(ComplianceTestCase):
+    _dev_sample = "juniper_qfx_copper"
+
+    def test_can_activate_the_auto_negotiation(self):
+        self.client.set_interface_auto_negotiation_state(self.test_port, state=ON)
+        interface = self.client.get_interface(self.test_port)
+
+        assert_that(interface.auto_negotiation, is_(True))
+
+    def test_can_deactivate_the_auto_negotiation(self):
+        self.client.set_interface_auto_negotiation_state(self.test_port, state=OFF)
+        interface = self.client.get_interface(self.test_port)
+
+        assert_that(interface.auto_negotiation, is_(False))
+
+    def test_fails_if_the_interface_does_not_exist(self):
+        with self.assertRaises(UnknownInterface) as expect:
+            self.client.set_interface_auto_negotiation_state('ge-0/0/128', state=ON)
+
+        assert_that(expect.exception, has_message("Unknown interface ge-0/0/128"))
+
+    def tearDown(self):
+        self.janitor.unset_interface_auto_negotiation_state(self.test_port)
+        super(SetInterfaceAutoNegotiationStateTest, self).tearDown()

--- a/tests/adapters/compliance_tests/unset_interface_auto_negotiation_state_test.py
+++ b/tests/adapters/compliance_tests/unset_interface_auto_negotiation_state_test.py
@@ -1,0 +1,39 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from hamcrest import assert_that, is_
+
+from netman.core.objects.exceptions import UnknownInterface
+from netman.core.objects.interface_states import ON, OFF
+from tests import has_message
+from tests.adapters.compliance_test_case import ComplianceTestCase
+
+
+class UnsetInterfaceAutoNegotiationStateTest(ComplianceTestCase):
+    _dev_sample = "juniper_qfx_copper"
+
+    def test_removes_the_state_completely(self):
+        self.try_to.set_interface_auto_negotiation_state(self.test_port, state=ON)
+
+        self.client.unset_interface_auto_negotiation_state(self.test_port)
+        interface = self.client.get_interface(self.test_port)
+
+        assert_that(interface.auto_negotiation, is_(None))
+
+    def test_fails_if_the_interface_does_not_exist(self):
+        with self.assertRaises(UnknownInterface) as expect:
+            self.client.unset_interface_auto_negotiation_state('ge-0/0/128')
+
+        assert_that(expect.exception, has_message("Unknown interface ge-0/0/128"))

--- a/tests/adapters/switches/cached_switch_test.py
+++ b/tests/adapters/switches/cached_switch_test.py
@@ -345,6 +345,45 @@ class CacheSwitchTest(unittest.TestCase):
 
         assert_that(self.switch.get_interface('xe-1/0/2').shutdown, is_(False))
 
+    def test_set_interface_auto_negotiation_state_off(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2', auto_negotiation=True)])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("set_interface_auto_negotiation_state").once() \
+            .with_args('xe-1/0/2', OFF)
+
+        self.switch.set_interface_auto_negotiation_state('xe-1/0/2', OFF)
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', auto_negotiation=False)]))
+
+    def test_set_interface_auto_negotiation_state_on(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2')])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("set_interface_auto_negotiation_state").once() \
+            .with_args('xe-1/0/2', ON)
+
+        self.switch.set_interface_auto_negotiation_state('xe-1/0/2', ON)
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', auto_negotiation=True)]))
+
+    def test_unset_interface_auto_negotiation_state(self):
+        self.real_switch_mock.should_receive("get_interfaces").once()\
+            .and_return([Interface('xe-1/0/2', auto_negotiation=False)])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("unset_interface_auto_negotiation_state").once().with_args('xe-1/0/2')
+
+        self.switch.unset_interface_auto_negotiation_state('xe-1/0/2')
+
+        assert_that(self.switch.get_interface('xe-1/0/2').auto_negotiation, is_(None))
+
     def test_set_interface_native_vlan(self):
         self.real_switch_mock.should_receive("get_interfaces").once() \
             .and_return([Interface('xe-1/0/2')])

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -2938,7 +2938,7 @@ class JuniperTest(unittest.TestCase):
             <rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/11.4R1/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
             <error-severity>error</error-severity>
             <error-message>
-            Invalid interface type in 'ne-0/0/9'
+            invalid interface type in 'ne-0/0/9'
             </error-message>
             </rpc-error>"""))))
 

--- a/tests/adapters/switches/remote_test.py
+++ b/tests/adapters/switches/remote_test.py
@@ -1216,6 +1216,41 @@ class RemoteSwitchTest(unittest.TestCase):
 
         self.switch.unset_interface_state("ge-0/0/6")
 
+    def test_enable_interface_auto_negotiation(self):
+        self.requests_mock.should_receive("put").once().with_args(
+            url=self.netman_url+'/switches/toto/interfaces/ge-0/0/6/auto-negotiation',
+            headers=self.headers,
+            data='true'
+        ).and_return(
+            Reply(
+                content='',
+                status_code=204))
+
+        self.switch.set_interface_auto_negotiation_state("ge-0/0/6", ON)
+
+    def test_disable_interface_auto_negotiation(self):
+        self.requests_mock.should_receive("put").once().with_args(
+            url=self.netman_url+'/switches/toto/interfaces/ge-0/0/6/auto-negotiation',
+            headers=self.headers,
+            data='false'
+        ).and_return(
+            Reply(
+                content='',
+                status_code=204))
+
+        self.switch.set_interface_auto_negotiation_state("ge-0/0/6", OFF)
+
+    def test_unset_interface_auto_negotiation_state(self):
+        self.requests_mock.should_receive("delete").once().with_args(
+            url=self.netman_url+'/switches/toto/interfaces/ge-0/0/6/auto-negotiation',
+            headers=self.headers
+        ).and_return(
+            Reply(
+                content='',
+                status_code=204))
+
+        self.switch.unset_interface_auto_negotiation_state("ge-0/0/6")
+
     def test_add_bond(self):
         self.requests_mock.should_receive("post").once().with_args(
             url=self.netman_url+'/switches/toto/bonds',

--- a/tests/api/switch_api_test.py
+++ b/tests/api/switch_api_test.py
@@ -162,9 +162,9 @@ class SwitchApiTest(BaseApiTest):
         self.switch_mock.should_receive('connect').once().ordered()
         self.switch_mock.should_receive('get_interfaces').and_return([
             Interface(name="FastEthernet0/3", shutdown=True, port_mode=ACCESS, access_vlan=1999),
-            Interface(name="GigabitEthernet0/6", shutdown=False, port_mode=DYNAMIC, access_vlan=1999, trunk_native_vlan=2999, trunk_vlans=[3001, 3000, 3002]),
+            Interface(name="GigabitEthernet0/6", shutdown=False, port_mode=DYNAMIC, access_vlan=1999, trunk_native_vlan=2999, trunk_vlans=[3001, 3000, 3002], auto_negotiation=True),
             Interface(name="ethernet 1/4", shutdown=False, port_mode=TRUNK, trunk_native_vlan=2999, trunk_vlans=[3001, 3000, 3002]),
-            Interface(name="GigabitEthernet0/8", shutdown=False, bond_master=12, port_mode=BOND_MEMBER, trunk_native_vlan=None, trunk_vlans=[]),
+            Interface(name="GigabitEthernet0/8", shutdown=False, bond_master=12, port_mode=BOND_MEMBER, trunk_native_vlan=None, trunk_vlans=[], auto_negotiation=False),
             ]).once().ordered()
         self.switch_mock.should_receive('disconnect').once().ordered()
 
@@ -494,6 +494,57 @@ class SwitchApiTest(BaseApiTest):
         self.switch_mock.should_receive('disconnect').once().ordered()
 
         result, code = self.delete("/switches/my.switch/interfaces/FastEthernet0/4/shutdown")
+
+        assert_that(code, equal_to(204))
+
+    def test_set_interface_auto_negotiation_state_off(self):
+        self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
+        self.switch_mock.should_receive('connect').once().ordered()
+        self.switch_mock.should_receive('set_interface_auto_negotiation_state').with_args('FastEthernet0/4', OFF).once().ordered()
+        self.switch_mock.should_receive('disconnect').once().ordered()
+
+        result, code = self.put("/switches/my.switch/interfaces/FastEthernet0/4/auto-negotiation", raw_data='false')
+
+        assert_that(code, equal_to(204))
+
+    def test_set_interface_auto_negotiation_state_on(self):
+        self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
+        self.switch_mock.should_receive('connect').once().ordered()
+        self.switch_mock.should_receive('set_interface_auto_negotiation_state').with_args('FastEthernet0/4', ON).once().ordered()
+        self.switch_mock.should_receive('disconnect').once().ordered()
+
+        result, code = self.put("/switches/my.switch/interfaces/FastEthernet0/4/auto-negotiation", raw_data='true')
+
+        assert_that(code, equal_to(204))
+
+    def test_set_interface_auto_negotiation_state_off_invalid_argument(self):
+        self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).never()
+        self.switch_mock.should_receive('connect').never()
+        self.switch_mock.should_receive('set_interface_auto_negotiation_state').with_args('FastEthernet0/4', OFF).never()
+        self.switch_mock.should_receive('disconnect').never()
+
+        result, code = self.put("/switches/my.switch/interfaces/FastEthernet0/4/auto-negotiation", raw_data='Patate')
+
+        assert_that(code, equal_to(400))
+        assert_that(result, equal_to({'error': 'Unreadable content "patate". Should be either "true" or "false"'}))
+
+    def test_set_interface_auto_negotiation_state_off_no_argument(self):
+        self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).never()
+        self.switch_mock.should_receive('connect').never()
+        self.switch_mock.should_receive('set_interface_auto_negotiation_state').with_args('FastEthernet0/4', OFF).never()
+        self.switch_mock.should_receive('disconnect').never()
+
+        result, code = self.put("/switches/my.switch/interfaces/FastEthernet0/4/auto-negotiation")
+        assert_that(code, equal_to(400))
+        assert_that(result, equal_to({'error': 'Unreadable content "". Should be either "true" or "false"'}))
+
+    def test_unset_interface_auto_negotiation_state(self):
+        self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
+        self.switch_mock.should_receive('connect').once().ordered()
+        self.switch_mock.should_receive('unset_interface_auto_negotiation_state').with_args('FastEthernet0/4').once().ordered()
+        self.switch_mock.should_receive('disconnect').once().ordered()
+
+        result, code = self.delete("/switches/my.switch/interfaces/FastEthernet0/4/auto-negotiation")
 
         assert_that(code, equal_to(204))
 


### PR DESCRIPTION
With the new fake-switches, the test can now pass.
The api, remote and cached switch implementations are
now available
Some test were wrong in providing error message with the
wrong case