### PR TITLE
Fix malformed interface name on dell get_interface

### DIFF
--- a/netman/adapters/switches/dell.py
+++ b/netman/adapters/switches/dell.py
@@ -307,7 +307,7 @@ class Dell(SwitchBase):
 
     def get_interface_data(self, interface_id):
         interface_data = self.shell.do("show running-config interface {}".format(interface_id))
-        if len(interface_data) > 0 and regex.match("ERROR.*", interface_data[0]):
+        if any(["Invalid input" in line or regex.match("ERROR.*", line) for line in interface_data]):
             raise UnknownInterface(interface_id)
         return interface_data
 

--- a/netman/adapters/switches/dell10g.py
+++ b/netman/adapters/switches/dell10g.py
@@ -159,8 +159,8 @@ class Dell10G(Dell):
 
     def get_interface_data(self, interface_id):
         interface_data = self.shell.do("show running-config interface {}".format(interface_id))
-        if len(interface_data) > 0 and regex.match(".*invalid interface.*", interface_data[0]):
-            raise UnknownInterface(interface_id)
+        if any(["Invalid input" in line or regex.match(".*invalid interface.*", line) for line in interface_data]):
+                raise UnknownInterface(interface_id)
         return interface_data
 
     def read_interface(self, interface_name):

--- a/tests/adapters/switches/dell10g_test.py
+++ b/tests/adapters/switches/dell10g_test.py
@@ -327,6 +327,16 @@ class Dell10GTest(unittest.TestCase):
 
         assert_that(str(expect.exception), equal_to("Unknown interface tengigabitethernet 0/0/9999"))
 
+    def test_get_malformed_interface_raises(self):
+        self.mocked_ssh_client.should_receive("do").with_args("show running-config interface patate").once().ordered().and_return([
+            "                                      ^",
+            "% Invalid input detected at '^' marker."])
+
+        with self.assertRaises(UnknownInterface) as expect:
+            self.switch.get_interface('patate')
+
+        assert_that(str(expect.exception), equal_to("Unknown interface patate"))
+
     def test_get_interfaces(self):
         self.mocked_ssh_client.should_receive("do").with_args("show interfaces status").and_return([
             "Port      Description               Vlan  Duplex Speed   Neg  Link   Flow Ctrl",

--- a/tests/adapters/switches/dell_test.py
+++ b/tests/adapters/switches/dell_test.py
@@ -391,6 +391,16 @@ class DellTest(unittest.TestCase):
         assert_that(interface.port_mode, is_(ACCESS))
         assert_that(interface.access_vlan, is_(1234))
 
+    def test_get_malformed_interface_raises(self):
+        self.mocked_ssh_client.should_receive("do").with_args("show running-config interface patate").once().ordered().and_return([
+            "                                      ^",
+            "% Invalid input detected at '^' marker."])
+
+        with self.assertRaises(UnknownInterface) as expect:
+            self.switch.get_interface('patate')
+
+        assert_that(str(expect.exception), equal_to("Unknown interface patate"))
+
     def test_get_nonexistent_interface_raises(self):
         self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ethernet 1/g9999").once().ordered().and_return([
             "ERROR: Invalid input!"


### PR DESCRIPTION
When an interface is malformed (has no second part) the code used to
return an empty interface because the underlying error was different.
This ensure the other error is implemented and raise the right
exception.