### PR TITLE
Add best-effort reset_interface on dell

### DIFF
--- a/netman/adapters/switches/dell10g.py
+++ b/netman/adapters/switches/dell10g.py
@@ -220,6 +220,9 @@ class Dell10G(Dell):
     def unset_bond_mtu(self, number):
         raise NotImplementedError()
 
+    def reset_interface(self, interface_id):
+        raise NotImplementedError()
+
 
 def has_trunk_vlans(interface_data):
     for line in interface_data:

--- a/netman/core/objects/exceptions.py
+++ b/netman/core/objects/exceptions.py
@@ -49,6 +49,11 @@ class OperationNotCompleted(NetmanException):
         super(OperationNotCompleted, self).__init__("An error occured while completing operation, no modifications have been applied : {0}".format(problem))
 
 
+class InterfaceResetIncomplete(NetmanException):
+    def __init__(self, interface_data=None):
+        super(InterfaceResetIncomplete, self).__init__("The interface reset has failed to remove these properties: {0}".format(interface_data))
+
+
 class UnknownVlan(UnknownResource):
     def __init__(self, vlan_number=None):
         super(UnknownVlan, self).__init__("Vlan {} not found".format(vlan_number))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 flexmock>=0.10.2
-fake-switches>=1.1.5
+fake-switches>=1.1.6
 MockSSH>=1.4.2
 Sphinx
 sphinxcontrib-httpdomain

--- a/tests/adapters/compliance_tests/reset_interface_test.py
+++ b/tests/adapters/compliance_tests/reset_interface_test.py
@@ -69,6 +69,13 @@ class ResetInterfaceTest(ComplianceTestCase):
 
         assert_that(self.client.get_interface(self.test_port).shutdown, is_(self.interface_before.shutdown))
 
+    def test_reset_interface_mtu(self):
+        self.try_to.set_interface_mtu(self.test_port, 4000)
+
+        self.client.reset_interface(self.test_port)
+
+        assert_that(self.client.get_interface(self.test_port).mtu, is_(self.interface_before.mtu))
+
     def test_raises_on_unknown_interface(self):
         with self.assertRaises(UnknownInterface):
             self.client.reset_interface('nonexistent 2/99')


### PR DESCRIPTION
Add a reset_interface on dell which deletes the attributes it supports
and clean the interface to the most of his knowledge, this allows to
strip the mtu from the interface on reset.

Fake-switches 1.1.6 now features the command 'no switchport mode' that
allows to set the interface in access (default) mode and remove
mode-related attributes.