### PR TITLE
Add connect timeout on telnet login hanging

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,11 +20,16 @@ from netaddr import IPNetwork
 
 from global_reactor import ThreadedReactor
 from tests.adapters.model_list import available_models
+from tests.adapters.shell.telnet_login_special_cases_test import hanging_password_telnet_hook
 from tests.adapters.shell.terminal_client_test import telnet_hook_to_reactor, ssh_hook_to_reactor
 
 
 def setup():
-    ThreadedReactor.start_reactor(available_models, reactor_hook_callbacks=[telnet_hook_to_reactor, ssh_hook_to_reactor])
+    ThreadedReactor.start_reactor(available_models, reactor_hook_callbacks=[
+        hanging_password_telnet_hook,
+        telnet_hook_to_reactor,
+        ssh_hook_to_reactor
+    ])
 
 
 def tearDown():

--- a/tests/adapters/shell/telnet_login_special_cases_test.py
+++ b/tests/adapters/shell/telnet_login_special_cases_test.py
@@ -1,0 +1,54 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from hamcrest import assert_that, is_
+from netman.adapters import shell
+from twisted.internet.protocol import Factory
+
+from netman.adapters.shell.telnet import TelnetClient
+from netman.core.objects.exceptions import ConnectTimeout
+from tests.adapters.shell.mock_telnet import MockTelnet
+
+
+class TelnetLoginSpecialCasesTest(unittest.TestCase):
+    client = TelnetClient
+    port = 10013
+
+    def test_hanging_during_the_login_process_raises_a_connect_timeout(self):
+        shell.default_connect_timeout = 0.1
+        with self.assertRaises(ConnectTimeout) as expect:
+            self.client("127.0.0.1", "admin", "1234", self.port)
+
+        assert_that(str(expect.exception), is_("Timed out while connecting to 127.0.0.1 on port 10013"))
+
+
+class PasswordHangingMockTelnet(MockTelnet):
+    def validate_password(self, _):
+        pass
+
+class SwitchTelnetFactory(Factory):
+    def __init__(self, prompt, commands):
+        self.prompt = prompt
+        self.commands = commands
+
+    def protocol(self):
+        return PasswordHangingMockTelnet(prompt=self.prompt, commands=self.commands)
+
+
+def hanging_password_telnet_hook(reactor):
+    reactor.listenTCP(interface="127.0.0.1",
+                      port=TelnetLoginSpecialCasesTest.port,
+                      factory=SwitchTelnetFactory("hostname>", []))

--- a/tests/adapters/shell/terminal_client_test.py
+++ b/tests/adapters/shell/terminal_client_test.py
@@ -227,7 +227,7 @@ class TelnetClientTest(TerminalClientTest):
     client = TelnetClient
     port = 10011
 
-    @patch('netman.adapters.shell.telnet._connect')
+    @patch('netman.adapters.shell.telnet.telnetlib.Telnet')
     @patch('netman.adapters.shell.telnet.TelnetClient._login', Mock())
     def test_changing_default_connect_timeout(self, connect_method_mock):
         shell.default_connect_timeout = 60
@@ -240,7 +240,7 @@ class TelnetClientTest(TerminalClientTest):
         TelnetClient(**self._get_some_credentials())
         self.assertEqual(120, connect_method_mock.call_args[0][2])
 
-    @patch('netman.adapters.shell.telnet._connect', Mock())
+    @patch('netman.adapters.shell.telnet.telnetlib.Telnet', Mock())
     @patch('netman.adapters.shell.telnet.TelnetClient._login', Mock())
     def test_changing_default_command_timeout(self):
         shell.default_command_timeout = 300


### PR DESCRIPTION
Sometime the password validation hangs due to backend issues.
Now we raise a ConnectTimeout instead of a CommandTimeout and
we use the connect timeout configuration.