### PR TITLE
Raise when enable fails

### DIFF
--- a/netman/adapters/shell/base.py
+++ b/netman/adapters/shell/base.py
@@ -14,7 +14,7 @@
 
 
 class TerminalClient(object):
-    def do(self, command, wait_for=None, include_last_line=False):
+    def do(self, command, wait_for=None, include_last_line=False, use_connect_timeout=False):
         raise NotImplemented()
 
     def send_key(self, key, wait_for=None, include_last_line=False):

--- a/netman/adapters/shell/ssh.py
+++ b/netman/adapters/shell/ssh.py
@@ -34,7 +34,7 @@ class SshClient(TerminalClient):
         self.username = username
         self.prompt = prompt
         self.command_timeout = command_timeout or shell.default_command_timeout
-        connect_timeout = connect_timeout or shell.default_connect_timeout
+        self.connect_timeout = connect_timeout or shell.default_connect_timeout
         self.reading_interval = reading_interval
         self.reading_chunk_size = reading_chunk_size
 
@@ -43,13 +43,15 @@ class SshClient(TerminalClient):
         self.channel = None
         self.full_log = ""
 
-        self._open_channel(host, port, username, password, connect_timeout)
+        self._open_channel(host, port, username, password, self.connect_timeout)
 
-    def do(self, command, wait_for=None, include_last_line=False):
+    def do(self, command, wait_for=None, include_last_line=False, use_connect_timeout=False):
         self.logger.debug("[SSH][{}@{}:{}] Send >> {}".format(self.username, self.host, self.port, command))
 
         self.channel.send(command + '\n')
-        return self._read_until(wait_for, include_last_line)
+
+        timeout = self.connect_timeout if use_connect_timeout else None
+        return self._read_until(wait_for, include_last_line, timeout)
 
     def send_key(self, key, wait_for=None, include_last_line=False):
         self.logger.debug("[SSH][{}@{}:{}] Send KEY >> {}".format(self.username, self.host, self.port, key))
@@ -85,8 +87,8 @@ class SshClient(TerminalClient):
 
         self._wait_for(self.prompt)
 
-    def _read_until(self, wait_for, include_last_line):
-        self._wait_for(wait_for or self.prompt)
+    def _read_until(self, wait_for, include_last_line, timeout=None):
+        self._wait_for(wait_for or self.prompt, timeout)
 
         lines = self.current_buffer.splitlines()[1:]
         if not include_last_line:
@@ -94,13 +96,13 @@ class SshClient(TerminalClient):
 
         return filter(None, lines)
 
-    def _wait_for(self, wait_for):
+    def _wait_for(self, wait_for, timeout=None):
         self.current_buffer = ''
 
         started_at = time.time()
         while not self.current_buffer.endswith(wait_for):
             while not self.channel.recv_ready():
-                if time.time() - started_at > self.command_timeout:
+                if time.time() - started_at > (timeout or self.command_timeout):
                     raise CommandTimeout(wait_for, self.current_buffer)
                 time.sleep(self.reading_interval)
 

--- a/netman/adapters/shell/telnet.py
+++ b/netman/adapters/shell/telnet.py
@@ -35,9 +35,10 @@ class TelnetClient(TerminalClient):
         self.telnet = self._connect()
         self._login(username, password)
 
-    def do(self, command, wait_for=None, include_last_line=False):
+    def do(self, command, wait_for=None, include_last_line=False, use_connect_timeout=False):
         self.telnet.write(str(command) + "\r\n")
-        result = self._read_until(wait_for)
+        timeout = self.connect_timeout if use_connect_timeout else None
+        result = self._read_until(wait_for, timeout)
 
         return _filter_input_and_empty_lines(command, include_last_line, result)
 
@@ -62,19 +63,19 @@ class TelnetClient(TerminalClient):
         result = self._wait_for_successful_login()
         self.full_log += result[len(password):].lstrip()
 
-    def _read_until(self, wait_for):
+    def _read_until(self, wait_for, timeout=None):
         expect = wait_for or self.prompt
         if isinstance(expect, basestring):
             expect = [expect]
         expect = ["{}$".format(re.escape(s)) for s in list(expect)]
 
-        result = self._wait_for(expect)
+        result = self._wait_for(expect, timeout)
         self.full_log += result
 
         return result
 
-    def _wait_for(self, expect):
-        result = self.telnet.expect(expect, timeout=self.command_timeout)
+    def _wait_for(self, expect, timeout=None):
+        result = self.telnet.expect(expect, timeout=timeout or self.command_timeout)
         if result[0] == -1:
             raise CommandTimeout(expect)
         return result[2]

--- a/netman/core/objects/exceptions.py
+++ b/netman/core/objects/exceptions.py
@@ -259,6 +259,13 @@ class CommandTimeout(Exception):
                                              .format(repr(wait_for), buffer))
 
 
+class PrivilegedAccessRefused(Exception):
+    def __init__(self, buffer=None):
+        super(PrivilegedAccessRefused, self).__init__("Could not get PRIVILEGED exec mode. "
+                                                      "Current read buffer: {}".
+                                                      format(buffer))
+
+
 class CouldNotConnect(Exception):
     def __init__(self, host=None, port=None):
         super(CouldNotConnect, self).__init__("Could not connect to {} on port {}".format(host, port))

--- a/tests/adapters/switches/dell10g_test.py
+++ b/tests/adapters/switches/dell10g_test.py
@@ -82,7 +82,7 @@ class Dell10GTest(unittest.TestCase):
         self.mocked_ssh_client = flexmock()
         ssh_client_class_mock.return_value = self.mocked_ssh_client
         self.mocked_ssh_client.should_receive("do").with_args("enable", wait_for=":").and_return([]).once().ordered()
-        self.mocked_ssh_client.should_receive("do").with_args("the_password").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("the_password", use_connect_timeout=True).and_return([]).once().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("terminal length 0").and_return([]).once().ordered()
 
         self.switch.connect()
@@ -103,7 +103,7 @@ class Dell10GTest(unittest.TestCase):
         self.mocked_ssh_client = flexmock()
         ssh_client_class_mock.return_value = self.mocked_ssh_client
         self.mocked_ssh_client.should_receive("do").with_args("enable", wait_for=":").and_return([]).once().ordered()
-        self.mocked_ssh_client.should_receive("do").with_args("the_password").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("the_password", use_connect_timeout=True).and_return([]).once().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("terminal length 0").and_return([]).once().ordered()
 
         self.switch.connect()


### PR DESCRIPTION
When enable fails, a PrivilegedAccessRefused is raised. Prior,
everything continued without interruption, and failed elsewhere.