### PR TITLE
Remove special timeout on enable

### DIFF
--- a/netman/adapters/shell/base.py
+++ b/netman/adapters/shell/base.py
@@ -14,7 +14,7 @@
 
 
 class TerminalClient(object):
-    def do(self, command, wait_for=None, include_last_line=False, use_connect_timeout=False):
+    def do(self, command, wait_for=None, include_last_line=False):
         raise NotImplemented()
 
     def send_key(self, key, wait_for=None, include_last_line=False):

--- a/netman/adapters/shell/telnet.py
+++ b/netman/adapters/shell/telnet.py
@@ -35,10 +35,9 @@ class TelnetClient(TerminalClient):
         self.telnet = self._connect()
         self._login(username, password)
 
-    def do(self, command, wait_for=None, include_last_line=False, use_connect_timeout=False):
+    def do(self, command, wait_for=None, include_last_line=False):
         self.telnet.write(str(command) + "\r\n")
-        timeout = self.connect_timeout if use_connect_timeout else None
-        result = self._read_until(wait_for, timeout)
+        result = self._read_until(wait_for)
 
         return _filter_input_and_empty_lines(command, include_last_line, result)
 
@@ -63,19 +62,19 @@ class TelnetClient(TerminalClient):
         result = self._wait_for_successful_login()
         self.full_log += result[len(password):].lstrip()
 
-    def _read_until(self, wait_for, timeout=None):
+    def _read_until(self, wait_for):
         expect = wait_for or self.prompt
         if isinstance(expect, basestring):
             expect = [expect]
         expect = ["{}$".format(re.escape(s)) for s in list(expect)]
 
-        result = self._wait_for(expect, timeout)
+        result = self._wait_for(expect)
         self.full_log += result
 
         return result
 
-    def _wait_for(self, expect, timeout=None):
-        result = self.telnet.expect(expect, timeout=timeout or self.command_timeout)
+    def _wait_for(self, expect):
+        result = self.telnet.expect(expect, timeout=self.command_timeout)
         if result[0] == -1:
             raise CommandTimeout(expect)
         return result[2]

--- a/netman/adapters/switches/dell.py
+++ b/netman/adapters/switches/dell.py
@@ -75,8 +75,7 @@ class Dell(SwitchBase):
         self.shell = self.shell_factory(**params)
 
         self.shell.do("enable", wait_for=":")
-        password_return = self.shell.do(self.switch_descriptor.password,
-                                        use_connect_timeout=True)
+        password_return = self.shell.do(self.switch_descriptor.password)
         if any(["Incorrect Password" in line for line in password_return]):
             raise PrivilegedAccessRefused(password_return)
 

--- a/tests/adapters/switches/dell10g_test.py
+++ b/tests/adapters/switches/dell10g_test.py
@@ -82,7 +82,7 @@ class Dell10GTest(unittest.TestCase):
         self.mocked_ssh_client = flexmock()
         ssh_client_class_mock.return_value = self.mocked_ssh_client
         self.mocked_ssh_client.should_receive("do").with_args("enable", wait_for=":").and_return([]).once().ordered()
-        self.mocked_ssh_client.should_receive("do").with_args("the_password", use_connect_timeout=True).and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("the_password").and_return([]).once().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("terminal length 0").and_return([]).once().ordered()
 
         self.switch.connect()
@@ -103,7 +103,7 @@ class Dell10GTest(unittest.TestCase):
         self.mocked_ssh_client = flexmock()
         ssh_client_class_mock.return_value = self.mocked_ssh_client
         self.mocked_ssh_client.should_receive("do").with_args("enable", wait_for=":").and_return([]).once().ordered()
-        self.mocked_ssh_client.should_receive("do").with_args("the_password", use_connect_timeout=True).and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("the_password").and_return([]).once().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("terminal length 0").and_return([]).once().ordered()
 
         self.switch.connect()

--- a/tests/adapters/switches/dell_test.py
+++ b/tests/adapters/switches/dell_test.py
@@ -84,8 +84,7 @@ class DellTest(unittest.TestCase):
         self.mocked_ssh_client = flexmock()
         ssh_client_class_mock.return_value = self.mocked_ssh_client
         self.mocked_ssh_client.should_receive("do").with_args("enable", wait_for=":").and_return([]).once().ordered()
-        self.mocked_ssh_client.should_receive("do").with_args("the_password", use_connect_timeout=True)\
-            .and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("the_password").and_return([]).once().ordered()
 
         self.switch.connect()
 
@@ -105,8 +104,7 @@ class DellTest(unittest.TestCase):
         self.mocked_ssh_client = flexmock()
         telnet_client_class_mock.return_value = self.mocked_ssh_client
         self.mocked_ssh_client.should_receive("do").with_args("enable", wait_for=":").and_return([]).once().ordered()
-        self.mocked_ssh_client.should_receive("do").with_args("the_password", use_connect_timeout=True)\
-            .and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("the_password").and_return([]).once().ordered()
 
         self.switch.connect()
 
@@ -127,7 +125,7 @@ class DellTest(unittest.TestCase):
         telnet_client_class_mock.return_value = self.mocked_ssh_client
         self.mocked_ssh_client.should_receive("do").with_args("enable", wait_for=":")\
             .and_return([]).once().ordered()
-        self.mocked_ssh_client.should_receive("do").with_args("the_password", use_connect_timeout=True)\
+        self.mocked_ssh_client.should_receive("do").with_args("the_password")\
             .and_return(['Incorrect Password!']).once().ordered()
 
         with self.assertRaises(PrivilegedAccessRefused) as expect:


### PR DESCRIPTION
It's not necessary that the enable command wait 5 minutes, the command
should not timeout at all or will issue a 'incorrect password' in a
timely matter, therefore we can get rid of this special case and let it
be handled in a generic manner.