### PR TITLE
Skip sdist / installation when using tox

### DIFF
--- a/tests/adapters/compliance_tests/remove_bond_test.py
+++ b/tests/adapters/compliance_tests/remove_bond_test.py
@@ -19,7 +19,7 @@ class RemoveBondTest(ComplianceTestCase):
         self.client.remove_bond(42)
 
         with self.assertRaises(UnknownBond):
-            assert_that(self.client.get_bond(42))
+            self.client.get_bond(42)
 
     def test_removes_bond_from_get_bonds(self):
         self.client.remove_bond(42)

--- a/tests/adapters/compliance_tests/reset_interface_test.py
+++ b/tests/adapters/compliance_tests/reset_interface_test.py
@@ -11,7 +11,7 @@ class ResetInterfaceTest(ComplianceTestCase):
 
     def setUp(self):
         super(ResetInterfaceTest, self).setUp()
-        self.interface_before = self.try_to.get_interface(self.test_port)
+        self.interface_before = self.client.get_interface(self.test_port)
 
     def tearDown(self):
         self.janitor.remove_vlan(90)

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
 envlist = py27
+skipsdist = True
 
 [testenv]
+usedevelop = True
 setenv = 
     PYTHONWARNINGS = default
+    PYTHONDONTWRITEBYTECODE = 1
 deps = -r{toxinidir}/test-requirements.txt
 commands =
     nosetests --tests tests


### PR DESCRIPTION
Additionally, a few mistakes from compliance tests were fixed. These mistakes have no effective change, unless when developing a switch that does not behave correctly.