### PR TITLE
Support correct protocol interface names

### DIFF
--- a/netman/adapters/switches/juniper/qfx_copper.py
+++ b/netman/adapters/switches/juniper/qfx_copper.py
@@ -48,3 +48,6 @@ class JuniperQfxCopperCustomStrategies(JuniperCustomStrategies):
 
     def set_native_vlan_id_node(self, interface_node, native_vlan_id_node):
         return interface_node.xpath("//interface")[0].append(native_vlan_id_node)
+
+    def get_protocols_interface_name(self, interface_name):
+        return interface_name

--- a/netman/adapters/switches/juniper/standard.py
+++ b/netman/adapters/switches/juniper/standard.py
@@ -52,3 +52,5 @@ class JuniperCustomStrategies(object):
     def set_native_vlan_id_node(self, interface_node, native_vlan_id_node):
         return interface_node.xpath("//ethernet-switching")[0].append(native_vlan_id_node)
 
+    def get_protocols_interface_name(self, interface_name):
+        return "{}.0".format(interface_name)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,9 +2,10 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 flexmock>=0.10.2
-fake-switches>=1.1.6
+fake-switches>=1.1.10
 MockSSH>=1.4.2
 Sphinx
 sphinxcontrib-httpdomain
 gunicorn>=19.4.5
 futures>=3.0.4
+

--- a/tests/adapters/compliance_tests/remove_bond_test.py
+++ b/tests/adapters/compliance_tests/remove_bond_test.py
@@ -46,6 +46,3 @@ class RemoveBondTest(ComplianceTestCase):
     def test_raises_on_out_of_range_bond_number(self):
         with self.assertRaises(UnknownBond):
             self.client.remove_bond(999)
-
-
-

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -4578,7 +4578,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -4593,7 +4593,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                 </interface>
               </rstp>
             </protocols>
@@ -4629,7 +4629,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -4644,7 +4644,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                   <edge/>
                   <no-root-port/>
                 </interface>
@@ -4668,7 +4668,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -4683,7 +4683,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                   <edge/>
                 </interface>
               </rstp>
@@ -4719,7 +4719,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -4734,7 +4734,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                   <no-root-port />
                 </interface>
               </rstp>
@@ -4770,7 +4770,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -4785,7 +4785,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                   <edge/>
                   <no-root-port/>
                 </interface>
@@ -4823,7 +4823,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -4838,7 +4838,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                   <edge/>
                 </interface>
               </rstp>
@@ -4874,7 +4874,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -4889,7 +4889,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                   <no-root-port />
                 </interface>
               </rstp>
@@ -4925,7 +4925,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -4940,7 +4940,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                 </interface>
               </rstp>
             </protocols>
@@ -4962,7 +4962,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ge-0/0/99</name>
+                      <name>ge-0/0/99.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -5252,7 +5252,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ae10</name>
+                      <name>ae10.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -5291,7 +5291,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ae10</name>
+                      <name>ae10.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -5309,7 +5309,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ae10</name>
+                  <name>ae10.0</name>
                   <edge/>
                   <no-root-port/>
                 </interface>
@@ -5346,7 +5346,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ae7</name>
+                      <name>ae7.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -5367,7 +5367,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <rstp>
                     <interface>
-                      <name>ae10</name>
+                      <name>ae10.0</name>
                     </interface>
                   </rstp>
                 </protocols>
@@ -5483,7 +5483,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <rstp>
                 <interface>
-                  <name>ge-0/0/1</name>
+                  <name>ge-0/0/1.0</name>
                   <edge />
                 </interface>
               </rstp>
@@ -5590,6 +5590,74 @@ class JuniperTest(unittest.TestCase):
 
         with self.assertRaises(UnknownInterface):
             self.switch.add_interface_to_bond('ge-0/0/99', 10)
+
+    def test_add_interface_to_bond_removing_protocols_avoid_deleting_other_interfaces(self):
+        self.netconf_mock.should_receive("get_config").with_args(source="candidate", filter=is_xml("""
+            <filter>
+              <configuration>
+                <interfaces/>
+                <vlans/>
+                <protocols>
+                  <rstp>
+                    <interface />
+                  </rstp>
+                </protocols>
+              </configuration>
+            </filter>
+        """)).and_return(a_configuration("""
+            <interfaces>
+              <interface>
+                <name>ae10</name>
+                <aggregated-ether-options>
+                  <link-speed>1g</link-speed>
+                </aggregated-ether-options>
+              </interface>
+              <interface>
+                <name>ge-0/0/1</name>
+              </interface>
+            </interfaces>
+            <vlans/>
+            <protocols>
+              <rstp>
+                <interface>
+                  <name>ge-0/0/1.0</name>
+                  <edge />
+                </interface>
+                <interface>
+                  <name>ge-0/0/10.0</name>
+                  <edge />
+                </interface>
+              </rstp>
+            </protocols>
+        """))
+
+        self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
+            <config>
+              <configuration>
+                <interfaces>
+                  <interface operation="replace">
+                    <name>ge-0/0/1</name>
+                    <ether-options>
+                      <ieee-802.3ad>
+                        <bundle>ae10</bundle>
+                      </ieee-802.3ad>
+                      <speed>
+                        <ethernet-1g/>
+                      </speed>
+                    </ether-options>
+                  </interface>
+                </interfaces>
+                <protocols>
+                  <rstp>
+                    <interface operation="delete">
+                      <name>ge-0/0/1</name>
+                    </interface>
+                  </rstp>
+                </protocols>
+              </configuration>
+            </config>""")).and_return(an_ok_response())
+
+        self.switch.add_interface_to_bond('ge-0/0/1', 10)
 
     def test_remove_interface_from_bond(self):
         self.netconf_mock.should_receive("edit_config").once().with_args(target="candidate", config=is_xml("""
@@ -5997,7 +6065,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <lldp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </lldp>
                 </protocols>
@@ -6039,7 +6107,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <lldp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </lldp>
                 </protocols>
@@ -6077,7 +6145,7 @@ class JuniperTest(unittest.TestCase):
                     <protocols>
                       <lldp>
                         <interface>
-                          <name>ge-0/0/99</name>
+                          <name>ge-0/0/99.0</name>
                         </interface>
                       </lldp>
                     </protocols>
@@ -6118,7 +6186,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <lldp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </lldp>
                 </protocols>
@@ -6133,7 +6201,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <lldp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                   <disable/>
                 </interface>
               </lldp>
@@ -6169,7 +6237,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <lldp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </lldp>
                 </protocols>
@@ -6184,7 +6252,7 @@ class JuniperTest(unittest.TestCase):
             <protocols>
               <lldp>
                 <interface>
-                  <name>ge-0/0/6</name>
+                  <name>ge-0/0/6.0</name>
                   <disable/>
                 </interface>
               </lldp>
@@ -6207,7 +6275,7 @@ class JuniperTest(unittest.TestCase):
                 <protocols>
                   <lldp>
                     <interface>
-                      <name>ge-0/0/6</name>
+                      <name>ge-0/0/6.0</name>
                     </interface>
                   </lldp>
                 </protocols>


### PR DESCRIPTION
For standard juniper switches (EX2200 and EX3300) the protocols
interface names have the unit in the name (.0) so when looking it
up, it should be considered, it was a bug that the system was
not considering it