### PR TITLE
Add specific requirements.txt for Read the Docs

### DIFF
--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Sphinx
+sphinxcontrib-httpdomain


### PR DESCRIPTION
Read the Docs doesn't supports multiple requirements files and the build
fail because application and test dependencies are necessary.