### PR TITLE
Add empty Juniper MX driver

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-index --no-emit-trusted-host --output-file constraints.txt requirements.txt
 #
-certifi==2017.11.5        # via requests
+certifi==2018.1.18        # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via flask
 ecdsa==0.13               # via paramiko
@@ -22,4 +22,4 @@ pycrypto==2.6.1           # via paramiko
 requests==2.18.4
 six==1.11.0               # via ncclient
 urllib3==1.22             # via requests
-werkzeug==0.13            # via flask
+werkzeug==0.14.1          # via flask

--- a/netman/adapters/switches/juniper/mx.py
+++ b/netman/adapters/switches/juniper/mx.py
@@ -1,0 +1,204 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from netman.adapters.switches.juniper.base import Juniper
+from netman.adapters.switches.juniper.qfx_copper import JuniperQfxCopperCustomStrategies
+
+
+class MxJuniper(Juniper):
+    def get_vlan(self, number):
+        raise NotImplementedError()
+
+    def get_vlans(self):
+        raise NotImplementedError()
+
+    def add_vlan(self, number, name=None):
+        raise NotImplementedError()
+
+    def remove_vlan(self, number):
+        raise NotImplementedError()
+
+    def get_interface(self, interface_id):
+        raise NotImplementedError()
+
+    def get_interfaces(self):
+        raise NotImplementedError()
+
+    def set_access_vlan(self, interface_id, vlan):
+        raise NotImplementedError()
+
+    def unset_interface_access_vlan(self, interface_id):
+        raise NotImplementedError()
+
+    def set_access_mode(self, interface_id):
+        raise NotImplementedError()
+
+    def set_trunk_mode(self, interface_id):
+        raise NotImplementedError()
+
+    def add_trunk_vlan(self, interface_id, vlan):
+        raise NotImplementedError()
+
+    def remove_trunk_vlan(self, interface_id, vlan):
+        raise NotImplementedError()
+
+    def set_interface_state(self, interface_id, state):
+        raise NotImplementedError()
+
+    def unset_interface_state(self, interface_id):
+        raise NotImplementedError()
+
+    def set_interface_auto_negotiation_state(self, interface_id, negotiation_state):
+        raise NotImplementedError()
+
+    def unset_interface_auto_negotiation_state(self, interface_id):
+        raise NotImplementedError()
+
+    def set_interface_native_vlan(self, interface_id, vlan):
+        raise NotImplementedError()
+
+    def unset_interface_native_vlan(self, interface_id):
+        raise NotImplementedError()
+
+    def reset_interface(self, interface_id):
+        raise NotImplementedError()
+
+    def get_vlan_interfaces(self, vlan_number):
+        raise NotImplementedError()
+
+    def add_ip_to_vlan(self, vlan_number, ip_network):
+        raise NotImplementedError()
+
+    def remove_ip_from_vlan(self, vlan_number, ip_network):
+        raise NotImplementedError()
+
+    def set_vlan_access_group(self, vlan_number, direction, name):
+        raise NotImplementedError()
+
+    def unset_vlan_access_group(self, vlan_number, direction):
+        raise NotImplementedError()
+
+    def set_vlan_vrf(self, vlan_number, vrf_name):
+        raise NotImplementedError()
+
+    def unset_vlan_vrf(self, vlan_number):
+        raise NotImplementedError()
+
+    def set_interface_description(self, interface_id, description):
+        raise NotImplementedError()
+
+    def unset_interface_description(self, interface_id):
+        raise NotImplementedError()
+
+    def edit_interface_spanning_tree(self, interface_id, edge=None):
+        raise NotImplementedError()
+
+    def add_bond(self, number):
+        raise NotImplementedError()
+
+    def remove_bond(self, number):
+        raise NotImplementedError()
+
+    def get_bond(self, number):
+        raise NotImplementedError()
+
+    def get_bonds(self):
+        raise NotImplementedError()
+
+    def add_interface_to_bond(self, interface, bond_number):
+        raise NotImplementedError()
+
+    def remove_interface_from_bond(self, interface):
+        raise NotImplementedError()
+
+    def set_bond_link_speed(self, number, speed):
+        raise NotImplementedError()
+
+    def set_bond_description(self, number, description):
+        raise NotImplementedError()
+
+    def unset_bond_description(self, number):
+        raise NotImplementedError()
+
+    def set_bond_trunk_mode(self, number):
+        raise NotImplementedError()
+
+    def set_bond_access_mode(self, number):
+        raise NotImplementedError()
+
+    def add_bond_trunk_vlan(self, number, vlan):
+        raise NotImplementedError()
+
+    def remove_bond_trunk_vlan(self, number, vlan):
+        raise NotImplementedError()
+
+    def set_bond_native_vlan(self, number, vlan):
+        raise NotImplementedError()
+
+    def unset_bond_native_vlan(self, number):
+        raise NotImplementedError()
+
+    def edit_bond_spanning_tree(self, number, edge=None):
+        raise NotImplementedError()
+
+    def add_vrrp_group(self, vlan_number, group_id, ips=None, priority=None, hello_interval=None, dead_interval=None,
+                       track_id=None, track_decrement=None):
+        raise NotImplementedError()
+
+    def remove_vrrp_group(self, vlan_id, group_id):
+        raise NotImplementedError()
+
+    def add_dhcp_relay_server(self, vlan_number, ip_address):
+        raise NotImplementedError()
+
+    def remove_dhcp_relay_server(self, vlan_number, ip_address):
+        raise NotImplementedError()
+
+    def set_interface_lldp_state(self, interface_id, enabled):
+        raise NotImplementedError()
+
+    def set_vlan_arp_routing_state(self, vlan_number, state):
+        raise NotImplementedError()
+
+    def set_vlan_icmp_redirects_state(self, vlan_number, state):
+        raise NotImplementedError()
+
+    def set_vlan_unicast_rpf_mode(self, vlan_number, mode):
+        raise NotImplementedError()
+
+    def unset_vlan_unicast_rpf_mode(self, vlan_number):
+        raise NotImplementedError()
+
+    def get_versions(self):
+        raise NotImplementedError()
+
+    def set_interface_mtu(self, interface_id, size):
+        raise NotImplementedError()
+
+    def unset_interface_mtu(self, interface_id):
+        raise NotImplementedError()
+
+    def set_bond_mtu(self, number, size):
+        raise NotImplementedError()
+
+    def unset_bond_mtu(self, number):
+        raise NotImplementedError()
+
+
+def netconf(switch_descriptor):
+    return MxJuniper(switch_descriptor, custom_strategies=JuniperMXCustomStrategies())
+
+
+class JuniperMXCustomStrategies(JuniperQfxCopperCustomStrategies):
+    pass

--- a/netman/core/switch_factory.py
+++ b/netman/core/switch_factory.py
@@ -14,6 +14,7 @@
 from netman.core.objects.flow_control_switch import FlowControlSwitch
 
 from netman.adapters.switches import cisco, juniper, dell, dell10g, brocade
+from netman.adapters.switches.juniper.mx import netconf as mx_netconf
 from netman.adapters.switches.remote import RemoteSwitch
 from netman.core.objects.switch_descriptor import SwitchDescriptor
 
@@ -24,6 +25,7 @@ factories = {
     "brocade_telnet": brocade.telnet,
     "juniper": juniper.standard.netconf,
     "juniper_qfx_copper": juniper.qfx_copper.netconf,
+    "juniper_mx": mx_netconf,
     "dell": dell.ssh,
     "dell_ssh": dell.ssh,
     "dell_telnet": dell.telnet,

--- a/test-constraints.txt
+++ b/test-constraints.txt
@@ -7,11 +7,11 @@
 alabaster==0.7.10         # via sphinx
 appdirs==1.4.3            # via rply, twisted
 args==0.1.0               # via clint
-asn1crypto==0.23.0        # via cryptography
+asn1crypto==0.24.0        # via cryptography
 astor==0.6.2              # via hy
-babel==2.5.1              # via sphinx
-certifi==2017.11.5
-cffi==1.11.2              # via cryptography
+babel==2.5.3              # via sphinx
+certifi==2018.1.18
+cffi==1.11.4              # via cryptography
 chardet==3.0.4
 click==6.7
 clint==0.5.1              # via hy
@@ -21,18 +21,18 @@ cryptography==2.1.4       # via twisted
 docutils==0.14            # via sphinx
 ecdsa==0.13
 enum34==1.1.6             # via cryptography, flake8
-fake-switches==1.1.12
+fake-switches==1.2.0
 flake8==3.4.1
 flask==0.12.2
 flexmock==0.10.2
 funcsigs==1.0.2           # via mock
 futures==3.2.0
 gunicorn==19.7.1
-hy==0.13.0                # via mockssh
+hy==0.14.0                # via mockssh
 idna==2.6
-imagesize==0.7.1          # via sphinx
+imagesize==1.0.0          # via sphinx
 incremental==17.5.0       # via twisted
-ipaddress==1.0.18         # via cryptography
+ipaddress==1.0.19         # via cryptography
 itsdangerous==0.24
 jinja2==2.10
 lxml==4.1.1
@@ -52,15 +52,15 @@ pycrypto==2.6.1
 pyflakes==1.5.0           # via flake8
 pygments==2.2.0           # via sphinx
 pyhamcrest==1.9.0
-pytz==2017.3              # via babel
+pytz==2018.3              # via babel
 requests==2.18.4
 rply==0.7.5               # via hy
 six==1.11.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.5.6
-sphinxcontrib-httpdomain==1.5.0
+sphinxcontrib-httpdomain==1.6.0
 tftpy==0.6.2              # via fake-switches
 twisted[conch]==16.6.0    # via fake-switches, mockssh
 urllib3==1.22
-werkzeug==0.13
+werkzeug==0.14.1
 zope.interface==4.4.3     # via twisted

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 flexmock>=0.10.2
-fake-switches>=1.1.12
+fake-switches>=1.2.0
 MockSSH>=1.4.2,!=1.4.5 # 1.4.5 has fixed dependency and freezes paramiko
 gunicorn>=19.4.5
 flake8==3.4.1

--- a/tests/adapters/compliance_test_case.py
+++ b/tests/adapters/compliance_test_case.py
@@ -39,8 +39,10 @@ def _create_associated_test_classes(test_case_name, test_class):
 
 def _wrap_tests_with_not_implemented_tolerance(test_class):
     for method in dir(test_class):
-        if method.startswith("test_") or method == "setUp":
+        if method.startswith("test_"):
             _wrap_test_method(method, test_class)
+        elif method == "setUp":
+            _wrap_setup_method(method, test_class)
     return test_class
 
 
@@ -52,5 +54,19 @@ def _wrap_test_method(method, test_class):
             old_method(obj)
         except NotImplementedError:
             raise SkipTest("Method is not implemented")
+    wrapper.__name__ = method
+    setattr(test_class, method, wrapper)
+
+
+def _wrap_setup_method(method, test_class):
+    old_method = getattr(test_class, method)
+
+    def wrapper(obj):
+        try:
+            old_method(obj)
+        except NotImplementedError:
+            obj.tearDown()
+            raise SkipTest("Method is not implemented")
+
     wrapper.__name__ = method
     setattr(test_class, method, wrapper)

--- a/tests/adapters/compliance_tests/get_interfaces_test.py
+++ b/tests/adapters/compliance_tests/get_interfaces_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from fake_switches.switch_configuration import AggregatedPort
 from hamcrest import assert_that, is_
 from netaddr import IPNetwork
 
@@ -25,14 +25,17 @@ class GetInterfacesTest(ComplianceTestCase):
 
         interfaces = self.client.get_interfaces()
 
-        assert_that([i.name for i in interfaces], is_([p.name for p in self.test_ports]))
+        assert_that([i.name for i in interfaces], is_(self._all_physical_test_ports()))
 
     def test_does_not_list_bonds(self):
         self.try_to.add_bond(1)
 
         interfaces = self.client.get_interfaces()
 
-        assert_that([i.name for i in interfaces], is_([p.name for p in self.test_ports]))
+        assert_that([i.name for i in interfaces], is_(self._all_physical_test_ports()))
+
+    def _all_physical_test_ports(self):
+        return [p.name for p in self.test_ports if not isinstance(p, AggregatedPort)]
 
     def test_does_not_list_interface_vlans(self):
         self.client.add_vlan(1000)
@@ -40,7 +43,7 @@ class GetInterfacesTest(ComplianceTestCase):
 
         interfaces = self.client.get_interfaces()
 
-        assert_that([i.name for i in interfaces], is_([p.name for p in self.test_ports]))
+        assert_that([i.name for i in interfaces], is_(self._all_physical_test_ports()))
 
     def tearDown(self):
         self.janitor.remove_bond(1)

--- a/tests/adapters/model_list.py
+++ b/tests/adapters/model_list.py
@@ -18,9 +18,10 @@ from fake_switches.cisco6500.cisco_core import Cisco6500SwitchCore
 from fake_switches.dell.dell_core import DellSwitchCore
 from fake_switches.dell10g.dell_core import Dell10GSwitchCore
 from fake_switches.juniper.juniper_core import JuniperSwitchCore
+from fake_switches.juniper_mx.juniper_mx_core import JuniperMXSwitchCore
 from fake_switches.juniper_qfx_copper.juniper_qfx_copper_core import JuniperQfxCopperSwitchCore
 from fake_switches.ssh_service import SwitchSshService
-from fake_switches.switch_configuration import Port
+from fake_switches.switch_configuration import Port, AggregatedPort
 from fake_switches.telnet_service import SwitchTelnetService
 from netman.core.objects.switch_descriptor import SwitchDescriptor
 
@@ -116,7 +117,12 @@ available_models = [
             Port("ge-0/0/1"),
             Port("ge-0/0/2"),
             Port("ge-0/0/3"),
-            Port("ge-0/0/4")
+            Port("ge-0/0/4"),
+            AggregatedPort("ae1"),
+            AggregatedPort("ae2"),
+            AggregatedPort("ae3"),
+            AggregatedPort("ae4"),
+            AggregatedPort("ae42")
         ]
     },
     {
@@ -134,7 +140,12 @@ available_models = [
             Port("ge-0/0/1"),
             Port("ge-0/0/2"),
             Port("ge-0/0/3"),
-            Port("ge-0/0/4")
+            Port("ge-0/0/4"),
+            AggregatedPort("ae1"),
+            AggregatedPort("ae2"),
+            AggregatedPort("ae3"),
+            AggregatedPort("ae4"),
+            AggregatedPort("ae42")
         ]
     },
     {
@@ -211,6 +222,29 @@ available_models = [
             Port("tengigabitethernet 1/0/2"),
             Port("tengigabitethernet 2/0/1"),
             Port("tengigabitethernet 2/0/2"),
+        ]
+    },
+    {
+        "switch_descriptor": SwitchDescriptor(
+            model="juniper_mx",
+            hostname="127.0.0.1",
+            port=11010,
+            username="root",
+            password="root",
+        ),
+        "test_port_name": "xe-0/0/3",
+        "core_class": JuniperMXSwitchCore,
+        "service_class": SwitchSshService,
+        "ports": [
+            Port("xe-0/0/1"),
+            Port("xe-0/0/2"),
+            Port("xe-0/0/3"),
+            Port("xe-0/0/4"),
+            AggregatedPort("ae1"),
+            AggregatedPort("ae2"),
+            AggregatedPort("ae3"),
+            AggregatedPort("ae4"),
+            AggregatedPort("ae42")
         ]
     }
 ]

--- a/tests/adapters/unified_tests/bond_management_test.py
+++ b/tests/adapters/unified_tests/bond_management_test.py
@@ -21,7 +21,7 @@ from tests.adapters.configured_test_case import skip_on_switches, ConfiguredTest
 class BondManagementTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("cisco", "brocade", "brocade_telnet", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("cisco", "brocade", "brocade_telnet", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_creating_deleting_a_bond(self):
         self.client.add_bond(3)
 

--- a/tests/adapters/unified_tests/dhcp_relay_server_test.py
+++ b/tests/adapters/unified_tests/dhcp_relay_server_test.py
@@ -21,7 +21,7 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class DhcpRelayServerTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
     def test_add_and_get_and_delete_dhcp_relay_server(self):
         try:
             self.client.add_vlan(2999, name="my-test-vlan")

--- a/tests/adapters/unified_tests/interface_management_test.py
+++ b/tests/adapters/unified_tests/interface_management_test.py
@@ -18,22 +18,22 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class InterfaceManagementTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx")
     def test_set_interface_state_off(self):
         self.client.set_interface_state(self.test_port, OFF)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx")
     def test_set_interface_state_on(self):
         self.client.set_interface_state(self.test_port, ON)
 
-    @skip_on_switches("cisco", "brocade", "brocade_telnet")
+    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx")
     def test_edit_spanning_tree(self):
         self.client.edit_interface_spanning_tree(self.test_port, edge=True)
 
-    @skip_on_switches("cisco", "brocade", "brocade_telnet")
+    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx")
     def test_set_interface_lldp_state(self):
         self.client.set_interface_lldp_state(self.test_port, enabled=True)
 
-    @skip_on_switches("cisco", "brocade", "brocade_telnet")
+    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx")
     def test_disable_lldp(self):
         self.client.set_interface_lldp_state(self.test_port, enabled=False)

--- a/tests/adapters/unified_tests/ip_management_test.py
+++ b/tests/adapters/unified_tests/ip_management_test.py
@@ -25,7 +25,7 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class IpManagementTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_adding_and_removing_ip_basic(self):
         self.client.add_vlan(2345)
 
@@ -58,7 +58,7 @@ class IpManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2345)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_adding_unavailable_ips_and_various_errors(self):
         self.client.add_vlan(2345)
 
@@ -91,7 +91,7 @@ class IpManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2345)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_handling_access_groups(self):
         self.client.add_vlan(2345)
 

--- a/tests/adapters/unified_tests/vlan_management_test.py
+++ b/tests/adapters/unified_tests/vlan_management_test.py
@@ -26,7 +26,7 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class VlanManagementTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_get_vlan(self):
         self.client.add_vlan(2999, name="my-test-vlan")
         self.client.set_vlan_access_group(2999, IN, "ACL-IN")
@@ -43,7 +43,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         assert_that(single_vlan, equal_to(vlan_from_list))
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_get_vlan_defaults(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -52,11 +52,12 @@ class VlanManagementTest(ConfiguredTestCase):
 
         assert_that(single_vlan, equal_to(vlan_from_list))
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_get_vlan_fails(self):
         with self.assertRaises(UnknownVlan):
             self.client.get_vlan(4000)
 
+    @skip_on_switches("juniper_mx")
     def test_adding_and_removing_a_vlan(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -70,6 +71,7 @@ class VlanManagementTest(ConfiguredTestCase):
         vlan = next((vlan for vlan in vlans if vlan.number == 2999), None)
         assert_that(vlan is None)
 
+    @skip_on_switches("juniper_mx")
     def test_setting_a_vlan_on_an_interface(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -81,6 +83,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2999)
 
+    @skip_on_switches("juniper_mx")
     def test_port_mode_trunk(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -88,6 +91,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2999)
 
+    @skip_on_switches("juniper_mx")
     def test_port_mode_access(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -95,6 +99,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2999)
 
+    @skip_on_switches("juniper_mx")
     def test_native_trunk(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -108,6 +113,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2999)
 
+    @skip_on_switches("juniper_mx")
     def test_passing_from_trunk_mode_to_access_gets_rid_of_stuff_in_trunk_mode(self):
         self.client.add_vlan(1100)
         self.client.add_vlan(1200)
@@ -143,6 +149,7 @@ class VlanManagementTest(ConfiguredTestCase):
         self.client.remove_vlan(1300)
         self.client.remove_vlan(1400)
 
+    @skip_on_switches("juniper_mx")
     def test_invalid_vlan_parameter_fails(self):
         with self.assertRaises(UnknownVlan):
             self.client.remove_vlan(2999)
@@ -166,7 +173,7 @@ class VlanManagementTest(ConfiguredTestCase):
         with self.assertRaises(UnknownResource):
             self.client.remove_trunk_vlan(self.test_port, vlan=2999)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx")
     def test_invalid_interface_parameter_fails(self):
         with self.assertRaises(UnknownInterface):
             self.client.set_interface_state('42/9999', ON)
@@ -216,7 +223,7 @@ class VlanManagementTest(ConfiguredTestCase):
         with self.assertRaises(UnknownInterface):
             self.client.set_interface_native_vlan('42/9999', 2999)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_vrf_management(self):
 
         self.client.add_vlan(2999, name="my-test-vlan")

--- a/tests/adapters/unified_tests/vrrp_test.py
+++ b/tests/adapters/unified_tests/vrrp_test.py
@@ -21,7 +21,7 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class VrrpTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx")
     def test_add_and_get_group(self):
         try:
             self.client.add_vlan(2999, name="my-test-vlan")


### PR DESCRIPTION
Compliance had to be fixed, because during the setup
if there was a exception causing the test to skip then the
teardown was not called leaving the connection open.