### PR TITLE
Implement get_vlans for Juniper MX

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -120,7 +120,7 @@ class Juniper(SwitchBase):
             if description_node is not None:
                 vlan.name = description_node.text
 
-            l3_if_type, l3_if_name = get_l3_interface(vlan_node)
+            l3_if_type, l3_if_name = self.custom_strategies.get_l3_interface(vlan_node)
             if l3_if_name is not None:
                 interface_vlan_node = first(config.xpath("data/configuration/interfaces/interface/name[text()=\"{}\"]/.."
                                                          "/unit/name[text()=\"{}\"]/..".format(l3_if_type, l3_if_name)))
@@ -172,7 +172,7 @@ class Juniper(SwitchBase):
         update = Update()
         self.custom_strategies.remove_update_vlans(update, vlan_name)
 
-        l3_if_type, l3_if_name = get_l3_interface(vlan_node)
+        l3_if_type, l3_if_name = self.custom_strategies.get_l3_interface(vlan_node)
         if l3_if_name is not None:
             update.add_interface(interface_unit_interface_removal(l3_if_type, l3_if_name))
 
@@ -1040,14 +1040,6 @@ def to_range(number_list):
         return "{}-{}".format(number_list[0], number_list[-1])
     else:
         return str(number_list[0])
-
-
-def get_l3_interface(vlan_node):
-    if_name_node = first(vlan_node.xpath("l3-interface"))
-    if if_name_node is not None:
-        return if_name_node.text.split(".")
-    else:
-        return None, None
 
 
 def parse_ips(interface_unit_node):

--- a/netman/adapters/switches/juniper/mx.py
+++ b/netman/adapters/switches/juniper/mx.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from ncclient.xml_ import to_ele, new_ele
 
-from netman.adapters.switches.juniper.base import Juniper
+from netman.adapters.switches.juniper.base import Juniper, first
 from netman.adapters.switches.juniper.qfx_copper import JuniperQfxCopperCustomStrategies
 from netman.core.objects.exceptions import BadVlanName, BadVlanNumber, VlanAlreadyExist, UnknownVlan
 
@@ -250,3 +250,10 @@ class JuniperMXCustomStrategies(JuniperQfxCopperCustomStrategies):
         elif "Must be a string" in message:
             raise BadVlanName()
         raise
+
+    def get_l3_interface(self, vlan_node):
+        if_name_node = first(vlan_node.xpath("routing-interface"))
+        if if_name_node is not None:
+            return if_name_node.text.split(".")
+        else:
+            return None, None

--- a/netman/adapters/switches/juniper/standard.py
+++ b/netman/adapters/switches/juniper/standard.py
@@ -14,7 +14,7 @@
 from ncclient.xml_ import to_ele, new_ele
 
 from netman.adapters.switches.juniper.base import interface_speed, interface_replace, interface_speed_update, \
-    first_text, bond_name, Juniper
+    first_text, bond_name, Juniper, first
 from netman.core.objects.exceptions import BadVlanName, BadVlanNumber, VlanAlreadyExist, UnknownVlan
 
 
@@ -115,3 +115,10 @@ class JuniperCustomStrategies(object):
                 raise BadVlanName()
 
         raise
+
+    def get_l3_interface(self, vlan_node):
+        if_name_node = first(vlan_node.xpath("l3-interface"))
+        if if_name_node is not None:
+            return if_name_node.text.split(".")
+        else:
+            return None, None


### PR DESCRIPTION
It was already possible to do a get_vlan, but the feature wasn't tested
and it was missing routing-interface