### PR TITLE
fix get_vlan not showing ips.

### DIFF
--- a/netman/adapters/switches/juniper/standard.py
+++ b/netman/adapters/switches/juniper/standard.py
@@ -97,16 +97,15 @@ class JuniperCustomStrategies(object):
             <name>{}</name>
         </vlan>""".format(name))
 
-    def get_vlans(self, config):
+    def vlan_nodes(self, config):
         return config.xpath("data/configuration/vlans/vlan")
 
-    def get_vlan_config(self, number, config):
-        vlan_node = config.xpath("data/configuration/vlans/vlan/vlan-id[text()=\"{}\"]/..".format(number))
+    def vlan_node(self, config, number):
+        vlan_node = first(config.xpath("data/configuration/vlans/vlan/vlan-id[text()=\"{}\"]/..".format(number)))
 
-        try:
-            return vlan_node[0]
-        except IndexError:
+        if vlan_node is None:
             raise UnknownVlan(number)
+        return vlan_node
 
     def manage_update_vlan_exception(self, message, number):
         if "being used by" in message:

--- a/tests/adapters/switches/juniper_mx_test.py
+++ b/tests/adapters/switches/juniper_mx_test.py
@@ -448,20 +448,26 @@ class JuniperMXTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
                 <filter>
                   <configuration>
-                    <bridge-domains>
-                      <domain>
-                        <vlan-id>40</vlan-id>
-                      </domain>
-                    </bridge-domains>
+                    <bridge-domains />
                     <interfaces />
                   </configuration>
                 </filter>
             """)).and_return(a_configuration("""
                 <bridge-domains>
                   <domain>
+                    <name>This-another-clam</name>
+                    <vlan-id>39</vlan-id>
+                    <routing-interface>irb.20</routing-interface>
+                  </domain>
+                  <domain>
                     <name>WITH-IF-MULTI-IP</name>
                     <vlan-id>40</vlan-id>
                     <routing-interface>irb.70</routing-interface>
+                  </domain>                  
+                  <domain>
+                    <name>This-yet-another-clam</name>
+                    <vlan-id>41</vlan-id>
+                    <routing-interface>irb.40</routing-interface>
                   </domain>
                 </bridge-domains>
                 <interfaces>
@@ -530,11 +536,7 @@ class JuniperMXTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
                 <filter>
                   <configuration>
-                    <bridge-domains>
-                      <domain>
-                        <vlan-id>10</vlan-id>
-                      </domain>
-                    </bridge-domains>
+                    <bridge-domains />
                     <interfaces />
                   </configuration>
                 </filter>
@@ -561,15 +563,17 @@ class JuniperMXTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
                 <filter>
                   <configuration>
-                    <bridge-domains>
-                      <domain>
-                        <vlan-id>10</vlan-id>
-                      </domain>
-                    </bridge-domains>
+                    <bridge-domains />
                     <interfaces />
                   </configuration>
                 </filter>
             """)).and_return(a_configuration("""
+                <bridge-domains>
+                  <domain>
+                    <name>This-another-clam</name>
+                    <vlan-id>39</vlan-id>
+                  </domain>
+                </bridge-domains>
             """))
 
         with self.assertRaises(UnknownVlan) as expect:
@@ -582,11 +586,7 @@ class JuniperMXTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
                 <filter>
                   <configuration>
-                    <bridge-domains>
-                      <domain>
-                        <vlan-id>20</vlan-id>
-                      </domain>
-                    </bridge-domains>
+                    <bridge-domains />
                     <interfaces />
                   </configuration>
                 </filter>

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -426,11 +426,7 @@ class JuniperTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
                 <filter>
                   <configuration>
-                    <vlans>
-                      <vlan>
-                        <vlan-id>10</vlan-id>
-                      </vlan>
-                    </vlans>
+                    <vlans />
                     <interfaces />
                   </configuration>
                 </filter>
@@ -457,11 +453,7 @@ class JuniperTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
                 <filter>
                   <configuration>
-                    <vlans>
-                      <vlan>
-                        <vlan-id>10</vlan-id>
-                      </vlan>
-                    </vlans>
+                    <vlans />
                     <interfaces />
                   </configuration>
                 </filter>
@@ -478,11 +470,7 @@ class JuniperTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
                 <filter>
                   <configuration>
-                    <vlans>
-                      <vlan>
-                        <vlan-id>20</vlan-id>
-                      </vlan>
-                    </vlans>
+                    <vlans />
                     <interfaces />
                   </configuration>
                 </filter>
@@ -567,11 +555,7 @@ class JuniperTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
                 <filter>
                   <configuration>
-                    <vlans>
-                      <vlan>
-                        <vlan-id>40</vlan-id>
-                      </vlan>
-                    </vlans>
+                    <vlans />
                     <interfaces />
                   </configuration>
                 </filter>
@@ -649,20 +633,24 @@ class JuniperTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="candidate", filter=is_xml("""
             <filter>
               <configuration>
-                <vlans>
-                  <vlan>
-                    <vlan-id>20</vlan-id>
-                  </vlan>
-                </vlans>
+                <vlans />
                 <interfaces />
               </configuration>
             </filter>
         """)).and_return(a_configuration("""
             <vlans>
               <vlan>
+                <name>NOT_GOOD_ONE</name>
+                <vlan-id>19</vlan-id>
+              </vlan>
+              <vlan>
                 <name>ON_IRB</name>
                 <vlan-id>20</vlan-id>
                 <l3-interface>irb.20</l3-interface>
+              </vlan>
+              <vlan>
+                <name>NOT_GOOD_TWO</name>
+                <vlan-id>21</vlan-id>
               </vlan>
             </vlans>
             <interfaces>
@@ -720,11 +708,7 @@ class JuniperTest(unittest.TestCase):
         self.netconf_mock.should_receive("get_config").with_args(source="running", filter=is_xml("""
             <filter>
               <configuration>
-                <vlans>
-                  <vlan>
-                    <vlan-id>40</vlan-id>
-                  </vlan>
-                </vlans>
+                <vlans />
                 <interfaces />
               </configuration>
             </filter>


### PR DESCRIPTION
Get a vlan by an ID does not include other vlan attributes since vlan-id
is not the collection identifier which is name.