### PR TITLE
ntp implementation for Cisco switches

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -12,7 +12,7 @@ flask==0.12.2
 idna==2.6                 # via requests
 itsdangerous==0.24        # via flask
 jinja2==2.10              # via flask
-lxml==4.2.0               # via ncclient
+lxml==4.2.1               # via ncclient
 markupsafe==1.0           # via jinja2
 ncclient==0.5.3
 netaddr==0.7.19

--- a/netman/adapters/switches/cached.py
+++ b/netman/adapters/switches/cached.py
@@ -377,6 +377,10 @@ class CachedSwitch(SwitchBase):
         self.real_switch.set_vlan_icmp_redirects_state(vlan_number, state)
         self.vlans_cache[vlan_number].icmp_redirects = state
 
+    def set_vlan_ntp_state(self, vlan_number, state):
+        self.real_switch.set_vlan_ntp_state(vlan_number, state)
+        self.vlans_cache[vlan_number].ntp = state
+
     def set_vlan_unicast_rpf_mode(self, vlan_number, mode):
         self.real_switch.set_vlan_unicast_rpf_mode(vlan_number, mode)
         self.vlans_cache[vlan_number].unicast_rpf_mode = mode

--- a/netman/adapters/switches/remote.py
+++ b/netman/adapters/switches/remote.py
@@ -309,6 +309,10 @@ class RemoteSwitch(SwitchBase):
         self.put('/vlans/{}/icmp-redirects'.format(vlan_number),
                  raw_data=_get_json_boolean(state))
 
+    def set_vlan_ntp_state(self, vlan_number, state):
+        self.put('/vlans/{}/ntp'.format(vlan_number),
+                 raw_data=_get_json_boolean(state))
+
     def set_vlan_unicast_rpf_mode(self, vlan_number, mode):
         self.put('/vlans/{}/unicast-rpf-mode'.format(vlan_number),
                  raw_data=str(mode))

--- a/netman/api/doc_config/api_samples/get_switch_hostname_vlans.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_vlans.json
@@ -24,7 +24,8 @@
       "dhcp_relay_servers": [],
       "arp_routing": null,
       "icmp_redirects": false,
-      "unicast_rpf_mode": null
+      "unicast_rpf_mode": null,
+      "ntp": false
    },
    {
       "number": 2,
@@ -61,6 +62,7 @@
       "dhcp_relay_servers": ["10.10.10.1"],
       "arp_routing": true,
       "icmp_redirects": true,
-      "unicast_rpf_mode": "STRICT"
+      "unicast_rpf_mode": "STRICT",
+      "ntp": null
    }
 ]

--- a/netman/api/doc_config/api_samples/get_switch_hostname_vlans_vlan.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_vlans_vlan.json
@@ -23,5 +23,6 @@
    "dhcp_relay_servers": [],
    "arp_routing": true,
    "icmp_redirects": false,
-   "unicast_rpf_mode": null
+   "unicast_rpf_mode": null,
+   "ntp": null
 }

--- a/netman/api/objects/vlan.py
+++ b/netman/api/objects/vlan.py
@@ -33,7 +33,8 @@ def to_api(vlan):
         dhcp_relay_servers=[str(server) for server in vlan.dhcp_relay_servers],
         arp_routing=vlan.arp_routing,
         icmp_redirects=vlan.icmp_redirects,
-        unicast_rpf_mode=vlan.unicast_rpf_mode
+        unicast_rpf_mode=vlan.unicast_rpf_mode,
+        ntp=vlan.ntp
     )
 
 

--- a/netman/api/switch_api.py
+++ b/netman/api/switch_api.py
@@ -45,6 +45,7 @@ class SwitchApi(SwitchApiBase):
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/dhcp-relay-server/<ip_network>', view_func=self.remove_dhcp_relay_server, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/arp-routing', view_func=self.set_vlan_arp_routing_state, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/icmp-redirects', view_func=self.set_vlan_icmp_redirects_state, methods=['PUT'])
+        server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/ntp', view_func=self.set_vlan_ntp_state, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/unicast-rpf-mode', view_func=self.set_vlan_unicast_rpf_mode, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/vlans/<vlan_number>/unicast-rpf-mode', view_func=self.unset_vlan_unicast_rpf_mode, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/interfaces', view_func=self.get_interfaces, methods=['GET'])
@@ -1031,6 +1032,23 @@ class SwitchApi(SwitchApiBase):
         """
 
         switch.set_vlan_icmp_redirects_state(vlan_number, state)
+
+        return 204, None
+
+    @to_response
+    @content(is_boolean)
+    @resource(Switch, Vlan)
+    def set_vlan_ntp_state(self, switch, vlan_number, state):
+        """
+        Enable or disable the ntp state of an interface
+
+        :arg str hostname: Hostname or IP of the switch
+        :arg int vlan_number: Vlan number, between 1 and 4096
+        :body:
+            ``true`` or ``false``
+        """
+
+        switch.set_vlan_ntp_state(vlan_number, state)
 
         return 204, None
 

--- a/netman/core/objects/switch_base.py
+++ b/netman/core/objects/switch_base.py
@@ -219,6 +219,9 @@ class SwitchOperations(BackwardCompatibleSwitchOperations):
     def unset_bond_mtu(self, number):
         raise NotImplementedError()
 
+    def set_vlan_ntp_state(self, vlan_number, state):
+        raise NotImplementedError()
+
 
 class SwitchBase(SwitchOperations):
     def __init__(self, switch_descriptor):

--- a/netman/core/objects/vlan.py
+++ b/netman/core/objects/vlan.py
@@ -19,7 +19,7 @@ from netman.core.objects.access_groups import OUT, IN
 class Vlan(Model):
     def __init__(self, number=None, name=None, ips=None, vrrp_groups=None, vrf_forwarding=None, access_group_in=None,
                  access_group_out=None, dhcp_relay_servers=None, arp_routing=None, icmp_redirects=None,
-                 unicast_rpf_mode=None):
+                 unicast_rpf_mode=None, ntp=None):
         self.number = number
         self.name = name
         self.access_groups = {IN: access_group_in, OUT: access_group_out}
@@ -30,3 +30,4 @@ class Vlan(Model):
         self.arp_routing = arp_routing
         self.icmp_redirects = icmp_redirects
         self.unicast_rpf_mode = unicast_rpf_mode
+        self.ntp = ntp

--- a/test-constraints.txt
+++ b/test-constraints.txt
@@ -17,11 +17,11 @@ click==6.7
 clint==0.5.1              # via hy
 configparser==3.5.0       # via flake8
 constantly==15.1.0        # via twisted
-cryptography==2.2         # via twisted
+cryptography==2.2.1       # via twisted
 docutils==0.14            # via sphinx
 ecdsa==0.13
 enum34==1.1.6             # via cryptography, flake8
-fake-switches==1.2.2
+fake-switches==1.2.4
 flake8==3.4.1
 flask==0.12.2
 flexmock==0.10.2
@@ -35,7 +35,7 @@ incremental==17.5.0       # via twisted
 ipaddress==1.0.19         # via cryptography
 itsdangerous==0.24
 jinja2==2.10
-lxml==4.2.0
+lxml==4.2.1
 markupsafe==1.0
 mccabe==0.6.1             # via flake8
 mock==2.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
 flexmock>=0.10.2
-fake-switches>=1.2.2
+fake-switches>=1.2.4
 MockSSH>=1.4.2,!=1.4.5 # 1.4.5 has fixed dependency and freezes paramiko
 gunicorn>=19.4.5
 flake8==3.4.1

--- a/tests/adapters/compliance_tests/set_vlan_ntp_state.py
+++ b/tests/adapters/compliance_tests/set_vlan_ntp_state.py
@@ -1,0 +1,33 @@
+from hamcrest import assert_that, is_
+
+from adapters.compliance_test_case import ComplianceTestCase
+from netman.core.objects.exceptions import UnknownVlan
+from tests import has_message
+
+
+class SetVlanNtpStateTest(ComplianceTestCase):
+    _dev_sample = "cisco"
+
+    def setUp(self):
+        super(SetVlanNtpStateTest, self).setUp()
+        self.client.add_vlan(2999, name="my-test-vlan")
+
+    def test_disables_ntp_when_given_false(self):
+        self.try_to.set_vlan_ntp_state(2999, False)
+        vlan = self.get_vlan_from_list(2999)
+        assert_that(vlan.ntp, is_(False))
+
+    def test_enables_ntp_when_given_true(self):
+        self.try_to.set_vlan_ntp_state(2999, True)
+        vlan = self.get_vlan_from_list(2999)
+        assert_that(vlan.ntp, is_(True))
+
+    def test_raises_UnknownVlan_when_operating_on_a_vlan_that_does_not_exist(self):
+        with self.assertRaises(UnknownVlan) as expect:
+            self.client.set_vlan_ntp_state(2000, False)
+
+        assert_that(expect.exception, has_message("Vlan 2000 not found"))
+
+    def tearDown(self):
+        self.janitor.remove_vlan(2999)
+        super(SetVlanNtpStateTest, self).tearDown()

--- a/tests/adapters/unified_tests/vlan_management_test.py
+++ b/tests/adapters/unified_tests/vlan_management_test.py
@@ -37,6 +37,7 @@ class VlanManagementTest(ConfiguredTestCase):
                                    track_id=self.test_vrrp_track_id, track_decrement=50, hello_interval=5, dead_interval=15)
         self.client.add_dhcp_relay_server(2999, IPAddress("10.10.10.11"))
         self.try_to.set_vlan_icmp_redirects_state(2999, False)
+        self.try_to.set_vlan_ntp_state(2999, False)
 
         single_vlan = self.client.get_vlan(2999)
         vlan_from_list = self.get_vlan_from_list(2999)

--- a/tests/api/switch_api_test.py
+++ b/tests/api/switch_api_test.py
@@ -66,14 +66,16 @@ class SwitchApiTest(BaseApiTest):
                  dhcp_relay_servers=[IPAddress("10.10.10.1")],
                  arp_routing=True,
                  icmp_redirects=True,
-                 unicast_rpf_mode=STRICT),
+                 unicast_rpf_mode=STRICT,
+                 ntp=None),
             Vlan(1, "One", [IPNetwork('1.1.1.1/24')], vrf_forwarding="MY_VRF", access_group_in="Blah_blah",
                  vrrp_groups=[
                      VrrpGroup(id=1, ips=[IPAddress('1.1.1.2')], priority=90, hello_interval=5, dead_interval=15,
                                track_id='101', track_decrement=50)
                  ],
                  arp_routing=None,
-                 icmp_redirects=False),
+                 icmp_redirects=False,
+                 ntp=False),
         ]).once().ordered()
         self.switch_mock.should_receive('disconnect').once().ordered()
 
@@ -573,6 +575,16 @@ class SwitchApiTest(BaseApiTest):
         self.switch_mock.should_receive('disconnect').once().ordered()
 
         result, code = self.put("/switches/my.switch/vlans/2500/icmp-redirects", raw_data='false')
+
+        assert_that(code, equal_to(204))
+
+    def test_disable_ntp(self):
+        self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
+        self.switch_mock.should_receive('connect').once().ordered()
+        self.switch_mock.should_receive('set_vlan_ntp_state').with_args(2500, False).once().ordered()
+        self.switch_mock.should_receive('disconnect').once().ordered()
+
+        result, code = self.put("/switches/my.switch/vlans/2500/ntp", raw_data='false')
 
         assert_that(code, equal_to(204))
 


### PR DESCRIPTION
we can now use a method called set_vlan_ntp_state in the API to set the
ntp state on Cisco switches

set_vlan_ntp_state to 'false' will trigger a 'ntp disable' on the
specified vlan interface.
set_vlan_ntp_state to 'true' will trigger a 'no ntp disable' on the
specified vlan interface.