### PR TITLE
Fixing transport hardcoding in eapi connection

### DIFF
--- a/tests/adapters/model_list.py
+++ b/tests/adapters/model_list.py
@@ -32,7 +32,7 @@ available_models = [
     {
         "switch_descriptor": SwitchDescriptor(
             model="arista",
-            hostname="127.0.0.1",
+            hostname="http://127.0.0.1",
             port=11015,
             username="root",
             password="root",

--- a/tests/adapters/switches/arista_test.py
+++ b/tests/adapters/switches/arista_test.py
@@ -1,8 +1,10 @@
 import unittest
 
+import pyeapi
 from flexmock import flexmock, flexmock_teardown
 from hamcrest import assert_that, has_length, equal_to, is_
 from pyeapi.api.vlans import Vlans
+from pyeapi.client import Node
 from pyeapi.eapilib import CommandError
 
 from netman.adapters.switches.arista import Arista
@@ -21,6 +23,26 @@ class AristaTest(unittest.TestCase):
 
     def tearDown(self):
         flexmock_teardown()
+
+    def test_arista_instance_with_proper_transport_http(self):
+        arista_eapi = flexmock(pyeapi)
+        arista_eapi.should_receive('connect').with_args(host="127.0.0.1", transport="http",
+                                                        username=None, return_node=True,
+                                                        password=None, port=None).once() \
+            .and_return(flexmock(Node(connection=None)))
+
+        switch = Arista(SwitchDescriptor(model='arista', hostname="http://127.0.0.1"))
+        switch._connect()
+
+    def test_arista_instance_with_proper_default_transport(self):
+        arista_eapi = flexmock(pyeapi)
+        arista_eapi.should_receive('connect').with_args(host="127.0.0.1", transport="https",
+                                                        username=None, return_node=True,
+                                                        password=None, port=None).once() \
+            .and_return(flexmock(Node(connection=None)))
+
+        switch = Arista(SwitchDescriptor(model='arista', hostname="127.0.0.1"))
+        switch._connect()
 
     def test_get_vlans(self):
         four_vlans_payload = vlans_payload(result=[{'vlans': {'1': vlan_data(name='default'),

--- a/tests/global_reactor.py
+++ b/tests/global_reactor.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
 import threading
 
 from fake_switches.switch_configuration import SwitchConfiguration
@@ -31,14 +31,19 @@ class ThreadedReactor(threading.Thread):
         for specs in models:
             switch_descriptor = specs["switch_descriptor"]
 
+            hostname = switch_descriptor.hostname
+            m = re.match('^https?:\/\/(.*)$', switch_descriptor.hostname.lower())
+            if m:
+                hostname = m.group(1)
+
             switch_config = SwitchConfiguration(
-                ip=switch_descriptor.hostname,
+                ip=hostname,
                 name="my_switch",
                 privileged_passwords=[switch_descriptor.password],
                 ports=specs["ports"])
 
             specs["service_class"](
-                switch_descriptor.hostname,
+                hostname,
                 port=switch_descriptor.port,
                 switch_core=specs["core_class"](switch_config),
                 users={switch_descriptor.username: switch_descriptor.password}


### PR DESCRIPTION
Behavior is now that, if a transport is provided in the hostname
(ie: http://127.0.0.1) than this transport will be used.
If none is provided (ie: 127.0.0.1) the default transport is 'https'