### PR TITLE
Push the transport decision in the factory

### DIFF
--- a/netman/core/switch_factory.py
+++ b/netman/core/switch_factory.py
@@ -20,6 +20,8 @@ from netman.core.objects.switch_descriptor import SwitchDescriptor
 
 factories = {
     "arista": arista.eapi,
+    "arista_http": arista.eapi_http,
+    "arista_https": arista.eapi_https,
     "cisco": cisco.ssh,
     "brocade": brocade.ssh,
     "brocade_ssh": brocade.ssh,

--- a/tests/adapters/compliance_tests/add_ip_to_vlan_test.py
+++ b/tests/adapters/compliance_tests/add_ip_to_vlan_test.py
@@ -20,7 +20,7 @@ from tests.adapters.compliance_test_case import ComplianceTestCase
 
 
 class AddIpToVlanTest(ComplianceTestCase):
-    _dev_sample = "arista"
+    _dev_sample = "arista_http"
 
     def setUp(self):
         super(AddIpToVlanTest, self).setUp()

--- a/tests/adapters/compliance_tests/add_vlan_test.py
+++ b/tests/adapters/compliance_tests/add_vlan_test.py
@@ -21,7 +21,7 @@ from tests.adapters.compliance_test_case import ComplianceTestCase
 
 
 class AddVlanTest(ComplianceTestCase):
-    _dev_sample = "arista"
+    _dev_sample = "arista_http"
 
     def test_creates_an_empty_vlan(self):
         self.client.add_vlan(1000)

--- a/tests/adapters/compliance_tests/remove_ip_from_vlan_test.py
+++ b/tests/adapters/compliance_tests/remove_ip_from_vlan_test.py
@@ -20,7 +20,7 @@ from tests.adapters.compliance_test_case import ComplianceTestCase
 
 
 class RemoveIpFromVlanTest(ComplianceTestCase):
-    _dev_sample = "arista"
+    _dev_sample = "arista_http"
 
     def setUp(self):
         super(RemoveIpFromVlanTest, self).setUp()

--- a/tests/adapters/model_list.py
+++ b/tests/adapters/model_list.py
@@ -31,8 +31,8 @@ from netman.core.objects.switch_descriptor import SwitchDescriptor
 available_models = [
     {
         "switch_descriptor": SwitchDescriptor(
-            model="arista",
-            hostname="http://127.0.0.1",
+            model="arista_http",
+            hostname="127.0.0.1",
             port=11015,
             username="root",
             password="root",

--- a/tests/adapters/unified_tests/bond_management_test.py
+++ b/tests/adapters/unified_tests/bond_management_test.py
@@ -21,7 +21,7 @@ from tests.adapters.configured_test_case import skip_on_switches, ConfiguredTest
 class BondManagementTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("cisco", "brocade", "brocade_telnet", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("cisco", "brocade", "brocade_telnet", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_creating_deleting_a_bond(self):
         self.client.add_bond(3)
 

--- a/tests/adapters/unified_tests/dhcp_relay_server_test.py
+++ b/tests/adapters/unified_tests/dhcp_relay_server_test.py
@@ -21,7 +21,7 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class DhcpRelayServerTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "arista_http")
     def test_add_and_get_and_delete_dhcp_relay_server(self):
         try:
             self.client.add_vlan(2999, name="my-test-vlan")

--- a/tests/adapters/unified_tests/interface_management_test.py
+++ b/tests/adapters/unified_tests/interface_management_test.py
@@ -18,22 +18,22 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class InterfaceManagementTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "arista_http")
     def test_set_interface_state_off(self):
         self.client.set_interface_state(self.test_port, OFF)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "arista_http")
     def test_set_interface_state_on(self):
         self.client.set_interface_state(self.test_port, ON)
 
-    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx", "arista")
+    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx", "arista_http")
     def test_edit_spanning_tree(self):
         self.client.edit_interface_spanning_tree(self.test_port, edge=True)
 
-    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx", "arista")
+    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx", "arista_http")
     def test_set_interface_lldp_state(self):
         self.client.set_interface_lldp_state(self.test_port, enabled=True)
 
-    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx", "arista")
+    @skip_on_switches("cisco", "brocade", "brocade_telnet", "juniper_mx", "arista_http")
     def test_disable_lldp(self):
         self.client.set_interface_lldp_state(self.test_port, enabled=False)

--- a/tests/adapters/unified_tests/ip_management_test.py
+++ b/tests/adapters/unified_tests/ip_management_test.py
@@ -25,7 +25,7 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class IpManagementTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_adding_and_removing_ip_basic(self):
         self.client.add_vlan(2345)
 
@@ -58,7 +58,7 @@ class IpManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2345)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_adding_unavailable_ips_and_various_errors(self):
         self.client.add_vlan(2345)
 
@@ -91,7 +91,7 @@ class IpManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2345)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_handling_access_groups(self):
         self.client.add_vlan(2345)
 

--- a/tests/adapters/unified_tests/vlan_management_test.py
+++ b/tests/adapters/unified_tests/vlan_management_test.py
@@ -26,7 +26,7 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class VlanManagementTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_get_vlan(self):
         self.client.add_vlan(2999, name="my-test-vlan")
         self.client.set_vlan_access_group(2999, IN, "ACL-IN")
@@ -44,7 +44,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         assert_that(single_vlan, equal_to(vlan_from_list))
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_get_vlan_defaults(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -53,12 +53,12 @@ class VlanManagementTest(ConfiguredTestCase):
 
         assert_that(single_vlan, equal_to(vlan_from_list))
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_get_vlan_fails(self):
         with self.assertRaises(UnknownVlan):
             self.client.get_vlan(4000)
 
-    @skip_on_switches("juniper_mx", "arista")
+    @skip_on_switches("juniper_mx", "arista_http")
     def test_adding_and_removing_a_vlan(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -72,7 +72,7 @@ class VlanManagementTest(ConfiguredTestCase):
         vlan = next((vlan for vlan in vlans if vlan.number == 2999), None)
         assert_that(vlan is None)
 
-    @skip_on_switches("juniper_mx", "arista")
+    @skip_on_switches("juniper_mx", "arista_http")
     def test_setting_a_vlan_on_an_interface(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -84,7 +84,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2999)
 
-    @skip_on_switches("juniper_mx", "arista")
+    @skip_on_switches("juniper_mx", "arista_http")
     def test_port_mode_trunk(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -92,7 +92,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2999)
 
-    @skip_on_switches("juniper_mx", "arista")
+    @skip_on_switches("juniper_mx", "arista_http")
     def test_port_mode_access(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -100,7 +100,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2999)
 
-    @skip_on_switches("juniper_mx", "arista")
+    @skip_on_switches("juniper_mx", "arista_http")
     def test_native_trunk(self):
         self.client.add_vlan(2999, name="my-test-vlan")
 
@@ -114,7 +114,7 @@ class VlanManagementTest(ConfiguredTestCase):
 
         self.client.remove_vlan(2999)
 
-    @skip_on_switches("juniper_mx", "arista")
+    @skip_on_switches("juniper_mx", "arista_http")
     def test_passing_from_trunk_mode_to_access_gets_rid_of_stuff_in_trunk_mode(self):
         self.client.add_vlan(1100)
         self.client.add_vlan(1200)
@@ -150,7 +150,7 @@ class VlanManagementTest(ConfiguredTestCase):
         self.client.remove_vlan(1300)
         self.client.remove_vlan(1400)
 
-    @skip_on_switches("juniper_mx", "arista")
+    @skip_on_switches("juniper_mx", "arista_http")
     def test_invalid_vlan_parameter_fails(self):
         with self.assertRaises(UnknownVlan):
             self.client.remove_vlan(2999)
@@ -174,7 +174,7 @@ class VlanManagementTest(ConfiguredTestCase):
         with self.assertRaises(UnknownResource):
             self.client.remove_trunk_vlan(self.test_port, vlan=2999)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "juniper_mx", "arista_http")
     def test_invalid_interface_parameter_fails(self):
         with self.assertRaises(UnknownInterface):
             self.client.set_interface_state('42/9999', ON)
@@ -224,7 +224,7 @@ class VlanManagementTest(ConfiguredTestCase):
         with self.assertRaises(UnknownInterface):
             self.client.set_interface_native_vlan('42/9999', 2999)
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_vrf_management(self):
 
         self.client.add_vlan(2999, name="my-test-vlan")

--- a/tests/adapters/unified_tests/vrrp_test.py
+++ b/tests/adapters/unified_tests/vrrp_test.py
@@ -21,7 +21,7 @@ from tests.adapters.configured_test_case import ConfiguredTestCase, skip_on_swit
 class VrrpTest(ConfiguredTestCase):
     __test__ = False
 
-    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista")
+    @skip_on_switches("juniper", "juniper_qfx_copper", "dell", "dell_telnet", "dell10g", "dell10g_telnet", "juniper_mx", "arista_http")
     def test_add_and_get_group(self):
         try:
             self.client.add_vlan(2999, name="my-test-vlan")


### PR DESCRIPTION
Just like cisco's decision to use telnet or ssh is decided on a driver
name level and not by detecting the port or weird stuff in the hostname
it makes more sense to choose either an HTTP or HTTPS driver and have
the hostname clear of unrelated information.

In addition, adding stuff to the hostname messes up the remote switch
when not in a session as it relays calls to /switches/hostname that ends
up /switches/http://hostname

Deprecation: While the transport-less arista driver has been existing
for a very short time, it's good practices to keep 100% backward
compatibility