### PR TITLE
Arista uses default_command_timeout

### DIFF
--- a/netman/adapters/switches/arista.py
+++ b/netman/adapters/switches/arista.py
@@ -7,6 +7,7 @@ from pyeapi.api.vlans import isvlan
 from pyeapi.eapilib import CommandError
 
 from netman import regex
+from netman.adapters.shell import default_command_timeout
 from netman.adapters.switches.util import split_on_dedent
 from netman.core.objects.exceptions import VlanAlreadyExist, UnknownVlan, BadVlanNumber, BadVlanName, \
     IPAlreadySet, IPNotAvailable, UnknownIP, DhcpRelayServerAlreadyExists, UnknownDhcpRelayServer, UnknownInterface, \
@@ -48,7 +49,8 @@ class Arista(SwitchBase):
                                    password=self.switch_descriptor.password,
                                    port=self.switch_descriptor.port,
                                    transport=self.transport,
-                                   return_node=True)
+                                   return_node=True,
+                                   timeout=default_command_timeout)
 
     def _disconnect(self):
         self.node = None

--- a/tests/adapters/switches/arista_test.py
+++ b/tests/adapters/switches/arista_test.py
@@ -948,7 +948,8 @@ class AristaFactoryTest(unittest.TestCase):
                        password="paw sword",
                        port=8888,
                        transport="trololo",
-                       return_node=True) \
+                       return_node=True,
+                       timeout=300) \
             .and_return(pyeapi_client_node)
 
         switch = Arista(
@@ -963,6 +964,29 @@ class AristaFactoryTest(unittest.TestCase):
         switch._connect()
 
         assert_that(switch.node, is_(pyeapi_client_node))
+
+    def test_arista_uses_command_timeout(self):
+        arista.default_command_timeout = 500
+
+        pyeapi_client_node = mock.sentinel
+
+        flexmock(pyeapi).should_receive('connect').once() \
+            .with_args(host="1.2.3.4",
+                       username=None,
+                       password=None,
+                       port=None,
+                       transport="trololo",
+                       return_node=True,
+                       timeout=500) \
+            .and_return(pyeapi_client_node)
+
+        switch = Arista(
+            SwitchDescriptor(model='arista',
+                             hostname="1.2.3.4"),
+            transport="trololo"
+        )
+
+        switch._connect()
 
     @ignore_deprecation_warnings
     def test_factory_transport_auto_detection_http(self):


### PR DESCRIPTION
Some arista takes long to reply, get_vlans can take a little more than
57s to render the configuration. The current timeout for arista is 60s.
to make sure we don't bust this timeout, we use the
default_command_timeout present in the shell, this allow us to wait
longer for command reply.