### PR TITLE
Fix documentation generation

### DIFF
--- a/netman/api/doc_config/index.rst
+++ b/netman/api/doc_config/index.rst
@@ -17,6 +17,7 @@ Cisco 6500       No                Yes                    Yes             Yes
 Juniper EX2200   Yes               No                     No              Yes
 Juniper QFX      Yes               No                     No              Yes
 Dell             No                Yes                    No              Yes
+Arista 7280R     No                No                     Yes             Yes
 ==============   ===============   ====================   =============   ===============
 
 API documentation

--- a/netman/api/switch_api.py
+++ b/netman/api/switch_api.py
@@ -388,6 +388,7 @@ class SwitchApi(SwitchApiBase):
     def set_vlan_mpls_ip_state(self, switch, vlan_number, state):
         """
         Sets the mpls ip state of a vlan
+
         :arg str hostname: Hostname or IP of the switch
         :arg int vlan_number: Vlan number, between 1 and 4096
         :body:

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -1,2 +1,3 @@
 Sphinx>=1.5.3,<1.6
 sphinxcontrib-httpdomain
+-r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,9 @@ setenv =
     PYTHONDONTWRITEBYTECODE = 1
 
 [testenv:docs]
+skip_install = true
 deps = -r{toxinidir}/rtd-requirements.txt
-commands = python setup.py build_sphinx --fresh-env
+commands = python setup.py build_sphinx {posargs} --fresh-env
 
 [testenv:bump-dependencies]
 skipsdist = True


### PR DESCRIPTION
This was broken since a refactor of dependencies, it will make sure that
rtd will install the applications requirements.

Bonus: Add arista to documentation