### PR TITLE
Netman remains untouched per docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN PBR_VERSION=0.0.0 pip install .
 EXPOSE 5000
 ENTRYPOINT [ "python" ]
 
-CMD [ "netman/main.py" ]
+CMD [ "netman/main.py", "--host=0.0.0.0"]

--- a/netman/main.py
+++ b/netman/main.py
@@ -58,7 +58,7 @@ def load_app(session_inactivity_timeout=None):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Netman Server')
-    parser.add_argument('--host', nargs='?', default="0.0.0.0")
+    parser.add_argument('--host', nargs='?', default="127.0.0.1")
     parser.add_argument('--port', type=int, nargs='?', default=5000)
     parser.add_argument('--session-inactivity-timeout', type=int, nargs='?')
 


### PR DESCRIPTION
When netman was containerized, main.py was changed. This change that so
netman is as it was before containerized.