### PR TITLE
Specify the README format for pipy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ author-email = opensource@internap.com
 summary = A unified REST API to provide vendor-agnostic network automation
 description-file =
     README.md
+long_description_content_type = text/markdown
 classifier =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
Set the format to markdown because by default it was set to rst.
Because of this, the deployement was failing because pipy was trying to parse it like a rst