### PR TITLE
Clean ssh connection in destructor

### DIFF
--- a/netman/adapters/shell/ssh.py
+++ b/netman/adapters/shell/ssh.py
@@ -108,3 +108,7 @@ class SshClient(TerminalClient):
             self.logger.debug("[SSH][{}@{}:{}] Recv << {}".format(self.username, self.host, self.port, repr(read)))
             self.full_log += read
             self.current_buffer += read
+
+    def __del__(self):
+        if self.client:
+            self.client.close()

--- a/tests/adapters/shell/terminal_client_test.py
+++ b/tests/adapters/shell/terminal_client_test.py
@@ -220,6 +220,13 @@ class SshClientTest(TerminalClientTest):
         ssh2 = SshClient(**self._get_some_credentials())
         self.assertEqual(600, ssh2.command_timeout)
 
+    @patch('netman.adapters.shell.ssh.SshClient._open_channel', Mock())
+    def test_close_on_deletion_prevents_leaking_filedescriptor(self):
+        ssh = SshClient(**self._get_some_credentials())
+        ssh.client = paramiko_connection = Mock()
+        del ssh
+        paramiko_connection.close.assert_called_once()
+
 
 class TelnetClientTest(TerminalClientTest):
     __test__ = True


### PR DESCRIPTION
Netman was leaking file descriptor with
established connection when runninng unit test.
It got up to a 1000 connections running and was
problematic because on osx the limit is now 256 by
default.
To reproduce, use a commit prior this one and run
in a shell with ulimit -n 256.

This also lower cpu usage during unit testing for some
reason.