### PR TITLE
Fix unit test + pep8

### DIFF
--- a/netman/adapters/switches/dell10g.py
+++ b/netman/adapters/switches/dell10g.py
@@ -230,7 +230,7 @@ class Dell10G(Dell):
                 vlan = regex[0]
                 mac_address = regex[1]
                 mac_address = "".join(mac_address.split('.'))
-                mac_address = ":".join([mac_address[x:x+2] for x in range(0, len(mac_address),2)])
+                mac_address = ":".join([mac_address[x:x+2] for x in range(0, len(mac_address), 2)])
                 interface = regex[2]
                 mac.append(MacAddress(vlan, mac_address, interface))
 

--- a/tests/api/switch_api_test.py
+++ b/tests/api/switch_api_test.py
@@ -1798,7 +1798,7 @@ class SwitchApiTest(BaseApiTest):
         result, code = self.get("/switches/my.switch/interfaces/mac-addresses")
 
         assert_that(code, equal_to(200))
-        assert_that(result, matches_fixture("get_mac_addresses.json"))
+        assert_that(result, matches_fixture("get_switch_hostname_mac_addresses.json"))
 
 
 class EmptyException(Exception):


### PR DESCRIPTION
Travis ci check is disabled for some reason
on pull request while they build on master.
this makes the test green again