### PR TITLE
Mac-address payload interface name changed

### DIFF
--- a/netman/adapters/switches/dell.py
+++ b/netman/adapters/switches/dell.py
@@ -303,18 +303,18 @@ class Dell(SwitchBase):
                 mac_address = "".join(mac_address.split('.'))
                 mac_address = ":".join([mac_address[x:x+2] for x in range(0, len(mac_address), 2)])
                 interface = regex[2]
-                type = self._parse_interface_type(interface)
+                interface, type = self._parse_interface_type(interface)
                 mac.append(MacAddress(vlan, mac_address, interface, type))
 
         return mac
 
     def _parse_interface_type(self, interface):
         if interface.startswith("vlan"):
-            return "Vlan"
+            return interface, "Vlan"
         elif interface.startswith("ch"):
-            return "Agregated"
+            return interface.replace("ch", "port-channel "), "Agregated"
         else:
-            return "Physical"
+            return interface, "Physical"
 
     def config(self):
         return SubShell(self.shell, enter="configure", exit_cmd='exit')

--- a/netman/adapters/switches/dell10g.py
+++ b/netman/adapters/switches/dell10g.py
@@ -232,18 +232,18 @@ class Dell10G(Dell):
                 mac_address = "".join(mac_address.split('.'))
                 mac_address = ":".join([mac_address[x:x+2] for x in range(0, len(mac_address), 2)])
                 interface = regex[2]
-                type = self._parse_interface_type(interface)
+                interface, type = self._parse_interface_type(interface)
                 mac.append(MacAddress(vlan, mac_address, interface, type))
 
         return mac
 
     def _parse_interface_type(self, interface):
         if interface.startswith("Vl"):
-            return "Vlan"
+            return interface, "Vlan"
         elif interface.startswith("Po"):
-            return "Agregated"
+            return interface.replace("Po", "port-channel "), "Agregated"
         else:
-            return "Physical"
+            return interface, "Physical"
 
     def set_interface_mtu(self, interface_id, size):
         raise NotImplementedError()

--- a/tests/adapters/switches/dell10g_test.py
+++ b/tests/adapters/switches/dell10g_test.py
@@ -1029,7 +1029,7 @@ class Dell10GTest(unittest.TestCase):
 
         assert_that(mac[2].vlan, is_(2227))
         assert_that(mac[2].mac_address, is_("FA:16:3E:ED:9D:0F"))
-        assert_that(mac[2].interface, is_("Po30"))
+        assert_that(mac[2].interface, is_("port-channel 30"))
         assert_that(mac[2].type, is_("Agregated"))
 
         assert_that(mac[6].vlan, is_(3217))

--- a/tests/adapters/switches/dell_test.py
+++ b/tests/adapters/switches/dell_test.py
@@ -1570,7 +1570,7 @@ class DellTest(unittest.TestCase):
 
         assert_that(mac[3].vlan, is_(3991))
         assert_that(mac[3].mac_address, is_("74:8E:F8:A7:1B:01"))
-        assert_that(mac[3].interface, is_("ch1"))
+        assert_that(mac[3].interface, is_("port-channel 1"))
         assert_that(mac[3].type, is_("Agregated"))
 
     def test_commit(self):


### PR DESCRIPTION
Changed the naming in the mac-address payload so that the interface
name matches what we get from the interface port list