### PR TITLE
recovery timeout option for interfaces and bonds

### DIFF
--- a/netman/adapters/switches/cached.py
+++ b/netman/adapters/switches/cached.py
@@ -317,11 +317,11 @@ class CachedSwitch(SwitchBase):
         self.interfaces_cache[interface_id].force_up = None
 
     def set_interface_recovery_timeout(self, interface_id, recovery_timeout):
-        self.real_switch.set_interface_lacp_force_up(interface_id, recovery_timeout)
+        self.real_switch.set_interface_recovery_timeout(interface_id, recovery_timeout)
         self.interfaces_cache[interface_id].recovery_timeout = recovery_timeout
 
     def set_bond_recovery_timeout(self, interface_id, recovery_timeout):
-        self.real_switch.set_bond_lacp_force_up(interface_id, recovery_timeout)
+        self.real_switch.set_bond_recovery_timeout(interface_id, recovery_timeout)
         self.interfaces_cache[interface_id].recovery_timeout = recovery_timeout
 
     def add_bond(self, number):

--- a/netman/adapters/switches/cached.py
+++ b/netman/adapters/switches/cached.py
@@ -316,6 +316,14 @@ class CachedSwitch(SwitchBase):
         self.real_switch.unset_interface_lacp_force_up(interface_id)
         self.interfaces_cache[interface_id].force_up = None
 
+    def set_interface_recovery_timeout(self, interface_id, recovery_timeout):
+        self.real_switch.set_interface_lacp_force_up(interface_id, recovery_timeout)
+        self.interfaces_cache[interface_id].recovery_timeout = recovery_timeout
+
+    def set_bond_recovery_timeout(self, interface_id, recovery_timeout):
+        self.real_switch.set_bond_lacp_force_up(interface_id, recovery_timeout)
+        self.interfaces_cache[interface_id].recovery_timeout = recovery_timeout
+
     def add_bond(self, number):
         self.real_switch.add_bond(number)
         self.bonds_cache.refresh_items.add(number)

--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -396,6 +396,18 @@ class Juniper(SwitchBase):
 
         self._push_interface_update(interface_id, update)
 
+    def set_interface_recovery_timeout(self, interface_id, recovery_timeout):
+        update_attributes = [to_ele("<recovery-timeout>{}</recovery-timeout>".format(recovery_timeout))]
+        update = Update()
+        update.add_interface(self.custom_strategies.interface_update(interface_id, "0", update_attributes))
+        self._push_interface_update(interface_id, update)
+
+    def set_bond_recovery_timeout(self, bond_id, recovery_timeout):
+        update_attributes = [to_ele("<recovery-timeout>{}</recovery-timeout>".format(recovery_timeout))]
+        update = Update()
+        update.add_interface(self.custom_strategies.interface_update(bond_name(bond_id), "0", update_attributes))
+        self._push_interface_update(bond_name(bond_id), update)
+
     def reset_interface(self, interface_id):
         content = to_ele("""
             <interface operation=\"delete\">
@@ -780,6 +792,8 @@ class Juniper(SwitchBase):
                 interface.auto_negotiation = False
             if first(interface_node.xpath('ether-options/ieee-802.3ad/lacp/force-up')) is not None:
                 interface.force_up = True
+            if first(interface_node.xpath("unit/family/ethernet-switching/recovery-timeout")) is not None:
+                interface.force_up = interface_node.xpath("unit/family/ethernet-switching/recovery-timeout")[0].text
         return interface
 
     def node_to_interface(self, interface_node, config):

--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -16,6 +16,7 @@ from ncclient import manager
 from ncclient.operations import RPCError, TimeoutExpiredError
 from ncclient.xml_ import new_ele, sub_ele, to_ele, to_xml
 from netaddr import IPNetwork
+import xml.etree.ElementTree as ET
 
 from netman import regex
 from netman.core.objects.access_groups import IN, OUT
@@ -793,7 +794,10 @@ class Juniper(SwitchBase):
             if first(interface_node.xpath('ether-options/ieee-802.3ad/lacp/force-up')) is not None:
                 interface.force_up = True
             if first(interface_node.xpath("unit/family/ethernet-switching/recovery-timeout")) is not None:
-                interface.force_up = interface_node.xpath("unit/family/ethernet-switching/recovery-timeout")[0].text
+                interface.recovery_timeout = \
+                    value_of(
+                        interface_node.xpath("unit/family/ethernet-switching/recovery-timeout/time-in-seconds"),
+                        transformer=int)
         return interface
 
     def node_to_interface(self, interface_node, config):

--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -16,7 +16,6 @@ from ncclient import manager
 from ncclient.operations import RPCError, TimeoutExpiredError
 from ncclient.xml_ import new_ele, sub_ele, to_ele, to_xml
 from netaddr import IPNetwork
-import xml.etree.ElementTree as ET
 
 from netman import regex
 from netman.core.objects.access_groups import IN, OUT

--- a/netman/adapters/switches/remote.py
+++ b/netman/adapters/switches/remote.py
@@ -276,6 +276,12 @@ class RemoteSwitch(SwitchBase):
     def unset_interface_lacp_force_up(self, interface_id):
         self.delete("/interfaces/" + interface_id + '/lacp-force-up')
 
+    def set_interface_recovery_timeout(self, interface_id, recovery_timeout):
+        self.put("/interfaces/{0}/recovery-timeout".format(interface_id), data={'recovery_timeout': recovery_timeout})
+
+    def set_bond_recovery_timeout(self, bond_id, recovery_timeout):
+        self.put("/bonds/{0}/recovery-timeout".format(bond_id), data={'recovery_timeout': recovery_timeout})
+
     def add_bond(self, number):
         self.post("/bonds", data={'number': number})
 

--- a/netman/api/doc_config/api_samples/get_switch_hostname_bond_v1.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_bond_v1.json
@@ -12,6 +12,7 @@
     "trunk_vlans": [],
     "auto_negotiation": null,
     "mtu": 1500,
-    "force_up": null
+    "force_up": null,
+    "recovery-timeout": null
   }
 }

--- a/netman/api/doc_config/api_samples/get_switch_hostname_bond_v1.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_bond_v1.json
@@ -13,6 +13,6 @@
     "auto_negotiation": null,
     "mtu": 1500,
     "force_up": null,
-    "recovery-timeout": null
+    "recovery_timeout": null
   }
 }

--- a/netman/api/doc_config/api_samples/get_switch_hostname_bonds_v1.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_bonds_v1.json
@@ -14,7 +14,7 @@
       "auto_negotiation": null,
       "mtu": 1500,
       "force_up": null,
-      "recovery-timeout": null
+      "recovery_timeout": null
     }
   },
   {
@@ -39,7 +39,7 @@
       "auto_negotiation": null,
       "mtu": null,
       "force_up": null,
-      "recovery-timeout": null
+      "recovery_timeout": null
     }
   },
   {
@@ -61,7 +61,7 @@
       "auto_negotiation": null,
       "mtu": null,
       "force_up": null,
-      "recovery-timeout": null
+      "recovery_timeout": null
     }
   }
 ]

--- a/netman/api/doc_config/api_samples/get_switch_hostname_bonds_v1.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_bonds_v1.json
@@ -13,7 +13,8 @@
       "trunk_vlans": [],
       "auto_negotiation": null,
       "mtu": 1500,
-      "force_up": null
+      "force_up": null,
+      "recovery-timeout": null
     }
   },
   {
@@ -37,7 +38,8 @@
       ],
       "auto_negotiation": null,
       "mtu": null,
-      "force_up": null
+      "force_up": null,
+      "recovery-timeout": null
     }
   },
   {
@@ -58,7 +60,8 @@
       ],
       "auto_negotiation": null,
       "mtu": null,
-      "force_up": null
+      "force_up": null,
+      "recovery-timeout": null
     }
   }
 ]

--- a/netman/api/doc_config/api_samples/get_switch_hostname_interface.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_interface.json
@@ -8,5 +8,6 @@
    "trunk_vlans": [3000, 3001, 3002],
    "auto_negotiation": null,
    "mtu": 1500,
-   "force_up": null
+   "force_up": null,
+   "recovery-timeout": null
 }

--- a/netman/api/doc_config/api_samples/get_switch_hostname_interface.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_interface.json
@@ -9,5 +9,5 @@
    "auto_negotiation": null,
    "mtu": 1500,
    "force_up": null,
-   "recovery-timeout": null
+   "recovery_timeout": null
 }

--- a/netman/api/doc_config/api_samples/get_switch_hostname_interfaces.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_interfaces.json
@@ -9,7 +9,8 @@
       "trunk_vlans": [3000, 3001, 3002],
       "auto_negotiation": null,
       "mtu": 1500,
-      "force_up": null
+      "force_up": null,
+      "recovery-timeout": null
    },
    {
       "name": "FastEthernet0/3",
@@ -21,7 +22,8 @@
       "trunk_vlans": [],
       "auto_negotiation": null,
       "mtu": null,
-      "force_up": null
+      "force_up": null,
+      "recovery-timeout": null
    },
    {
       "name": "GigabitEthernet0/6",
@@ -33,7 +35,8 @@
       "trunk_vlans": [3000, 3001, 3002],
       "auto_negotiation": true,
       "mtu": null,
-      "force_up": null
+      "force_up": null,
+      "recovery-timeout": null
    },
    {
       "name": "GigabitEthernet0/8",
@@ -45,6 +48,7 @@
       "trunk_vlans": [],
       "auto_negotiation": false,
       "mtu": null,
-      "force_up": null
+      "force_up": null,
+      "recovery-timeout": null
    }
 ]

--- a/netman/api/doc_config/api_samples/get_switch_hostname_interfaces.json
+++ b/netman/api/doc_config/api_samples/get_switch_hostname_interfaces.json
@@ -10,7 +10,7 @@
       "auto_negotiation": null,
       "mtu": 1500,
       "force_up": null,
-      "recovery-timeout": null
+      "recovery_timeout": null
    },
    {
       "name": "FastEthernet0/3",
@@ -23,7 +23,7 @@
       "auto_negotiation": null,
       "mtu": null,
       "force_up": null,
-      "recovery-timeout": null
+      "recovery_timeout": null
    },
    {
       "name": "GigabitEthernet0/6",
@@ -36,7 +36,7 @@
       "auto_negotiation": true,
       "mtu": null,
       "force_up": null,
-      "recovery-timeout": null
+      "recovery_timeout": null
    },
    {
       "name": "GigabitEthernet0/8",
@@ -49,6 +49,6 @@
       "auto_negotiation": false,
       "mtu": null,
       "force_up": null,
-      "recovery-timeout": null
+      "recovery_timeout": null
    }
 ]

--- a/netman/api/objects/bond.py
+++ b/netman/api/objects/bond.py
@@ -53,7 +53,8 @@ class V1(Serializer):
                 access_vlan=bond.access_vlan,
                 trunk_native_vlan=bond.trunk_native_vlan,
                 trunk_vlans=bond.trunk_vlans,
-                mtu=bond.mtu
+                mtu=bond.mtu,
+                recovery_timeout=bond.recovery_timeout
             ))
         )
 

--- a/netman/api/objects/interface.py
+++ b/netman/api/objects/interface.py
@@ -29,12 +29,13 @@ class V1(Serializer):
             name=interface.name,
             bond_master=interface.bond_master,
             auto_negotiation=interface.auto_negotiation,
-            force_up=interface.force_up
+            force_up=interface.force_up,
+            recovery_timeout=interface.recovery_timeout
         )
 
     def to_core(self, serialized):
         params = dict(vars(base_interface.to_core(serialized)))
-        params.update(sub_dict(serialized, 'name', 'bond_master', 'auto_negotiation', 'force_up'))
+        params.update(sub_dict(serialized, 'name', 'bond_master', 'auto_negotiation', 'force_up', 'recovery_timeout'))
         return Interface(**params)
 
 

--- a/netman/api/switch_api.py
+++ b/netman/api/switch_api.py
@@ -77,7 +77,7 @@ class SwitchApi(SwitchApiBase):
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/auto-negotiation', view_func=self.unset_interface_auto_negotiation_state, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/lacp-force-up', view_func=self.set_interface_lacp_force_up, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/lacp-force-up', view_func=self.unset_interface_lacp_force_up, methods=['DELETE'])
-        server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/recovery-timeout ', view_func=self.set_interface_recovery_timeout, methods=['PUT'])
+        server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/recovery-timeout', view_func=self.set_interface_recovery_timeout, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/mtu', view_func=self.set_interface_mtu, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/mtu', view_func=self.unset_interface_mtu, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/bonds', view_func=self.get_bonds, methods=['GET'])

--- a/netman/api/switch_api.py
+++ b/netman/api/switch_api.py
@@ -20,7 +20,7 @@ from netman.api.switch_api_base import SwitchApiBase
 from netman.api.validators import Switch, is_boolean, is_vlan_number, Interface, Vlan, resource, content, is_ip_network, \
     IPNetworkResource, is_access_group_name, Direction, is_vlan, is_bond, Bond, \
     is_bond_link_speed, is_bond_number, is_description, is_vrf_name, \
-    is_vrrp_group, VrrpGroup, is_dict_with, optional, is_type, is_int, is_unincast_rpf_mode
+    is_vrrp_group, VrrpGroup, is_dict_with, optional, is_type, is_int, is_unincast_rpf_mode, is_recovery_timeout
 from netman.core.objects.interface_states import OFF, ON
 from netman.core.validator import is_valid_mpls_state
 
@@ -77,6 +77,7 @@ class SwitchApi(SwitchApiBase):
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/auto-negotiation', view_func=self.unset_interface_auto_negotiation_state, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/lacp-force-up', view_func=self.set_interface_lacp_force_up, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/lacp-force-up', view_func=self.unset_interface_lacp_force_up, methods=['DELETE'])
+        server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/recovery-timeout ', view_func=self.set_interface_recovery_timeout, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/mtu', view_func=self.set_interface_mtu, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/interfaces/<path:interface_id>/mtu', view_func=self.unset_interface_mtu, methods=['DELETE'])
         server.add_url_rule('/switches/<hostname>/bonds', view_func=self.get_bonds, methods=['GET'])
@@ -96,6 +97,8 @@ class SwitchApi(SwitchApiBase):
         server.add_url_rule('/switches/<hostname>/bonds/<bond_number>/spanning-tree', view_func=self.edit_bond_spanning_tree, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/bonds/<bond_number>/mtu', view_func=self.set_bond_mtu, methods=['PUT'])
         server.add_url_rule('/switches/<hostname>/bonds/<bond_number>/mtu', view_func=self.unset_bond_mtu, methods=['DELETE'])
+        server.add_url_rule('/switches/<hostname>/bonds/<bond_number>/recovery-timeout', view_func=self.set_bond_recovery_timeout, methods=['PUT'])
+
         return self
 
     @to_response
@@ -525,6 +528,34 @@ class SwitchApi(SwitchApiBase):
         """
 
         switch.unset_interface_lacp_force_up(interface_id)
+        return 204, None
+
+    @to_response
+    @content(is_recovery_timeout)
+    @resource(Switch, Interface)
+    def set_interface_recovery_timeout(self, switch, interface_id, recovery_timeout):
+        """
+        Sets lacp force_up state of an interface
+
+        :arg str hostname: Hostname or IP of the switch
+        :arg str interface_id: Interface name (ex. ``FastEthernet0/1``, ``ethernet1/11``)
+        :arg int recovery_timeout: Recovery timeout
+        """
+        switch.set_interface_recovery_timeout(interface_id, recovery_timeout)
+        return 204, None
+
+    @to_response
+    @content(is_recovery_timeout)
+    @resource(Switch, Bond)
+    def set_bond_recovery_timeout(self, switch, bond_number, recovery_timeout):
+        """
+        Sets recovery timeout of an interface
+
+        :arg str hostname: Hostname or IP of the switch
+        :arg str bond_id: Bond id (ex. ``1``, ``2``)
+        :arg int recovery_timeout: Recovery timeout (ex. ``100``, ``200``)
+        """
+        switch.set_bond_recovery_timeout(bond_number, recovery_timeout)
         return 204, None
 
     @to_response

--- a/netman/api/validators.py
+++ b/netman/api/validators.py
@@ -24,7 +24,7 @@ from netman.api.api_utils import BadRequest, MultiContext
 from netman.core.objects.access_groups import IN, OUT
 from netman.core.objects.exceptions import UnknownResource, BadVlanNumber, \
     BadVlanName, BadBondNumber, BadBondLinkSpeed, MalformedSwitchSessionRequest, \
-    BadVrrpGroupNumber
+    BadVrrpGroupNumber, BadRecoveryTimeoutNumber
 from netman.core.objects.unicast_rpf_modes import STRICT
 
 
@@ -75,6 +75,7 @@ class Bond:
         self.bond = None
 
     def process(self, parameters):
+        print parameters
         self.bond = is_bond_number(parameters.pop('bond_number'))['bond_number']
 
     def __enter__(self):
@@ -342,6 +343,19 @@ def is_bond(data, **_):
         'bond_number': is_bond_number(json_data["number"])['bond_number'],
     }
 
+
+def is_recovery_timeout(data, **_):
+    try:
+        json_data = json.loads(data)
+    except ValueError:
+        raise BadRequest("Malformed content, should be a JSON object")
+
+    if "recovery_timeout" not in json_data:
+        raise BadRecoveryTimeoutNumber()
+
+    return {
+        'recovery_timeout': json_data["recovery_timeout"]
+    }
 
 def is_unincast_rpf_mode(data, **_):
     if data not in [STRICT]:

--- a/netman/api/validators.py
+++ b/netman/api/validators.py
@@ -75,7 +75,6 @@ class Bond:
         self.bond = None
 
     def process(self, parameters):
-        print parameters
         self.bond = is_bond_number(parameters.pop('bond_number'))['bond_number']
 
     def __enter__(self):
@@ -356,6 +355,7 @@ def is_recovery_timeout(data, **_):
     return {
         'recovery_timeout': json_data["recovery_timeout"]
     }
+
 
 def is_unincast_rpf_mode(data, **_):
     if data not in [STRICT]:

--- a/netman/core/objects/exceptions.py
+++ b/netman/core/objects/exceptions.py
@@ -224,6 +224,11 @@ class BadBondNumber(InvalidValue):
         super(BadBondNumber, self).__init__("Bond number is invalid")
 
 
+class BadRecoveryTimeoutNumber(InvalidValue):
+    def __init__(self):
+        super(BadRecoveryTimeoutNumber, self).__init__("Recovery timeout number is invalid")
+
+
 class InterfaceNotInBond(UnknownResource):
     def __init__(self):
         super(InterfaceNotInBond, self).__init__("Interface not associated to specified bond")

--- a/netman/core/objects/interface.py
+++ b/netman/core/objects/interface.py
@@ -17,21 +17,20 @@ from netman.core.objects import Model
 
 class BaseInterface(Model):
     def __init__(self, shutdown=None, port_mode=None, access_vlan=None,
-                 trunk_native_vlan=None, trunk_vlans=None, mtu=None):
+                 trunk_native_vlan=None, trunk_vlans=None, mtu=None, recovery_timeout=None):
         self.shutdown = shutdown
         self.port_mode = port_mode
         self.access_vlan = access_vlan
         self.trunk_native_vlan = trunk_native_vlan
         self.trunk_vlans = trunk_vlans or []
         self.mtu = mtu
+        self.recovery_timeout = recovery_timeout
 
 
 class Interface(BaseInterface):
-    def __init__(self, name=None, bond_master=None, auto_negotiation=None, force_up=None, recovery_timeout=None,
-                 **interface):
+    def __init__(self, name=None, bond_master=None, auto_negotiation=None, force_up=None, **interface):
         super(Interface, self).__init__(**interface)
         self.name = name
         self.bond_master = bond_master
         self.auto_negotiation = auto_negotiation
         self.force_up = force_up
-        self.recovery_timeout = recovery_timeout

--- a/netman/core/objects/interface.py
+++ b/netman/core/objects/interface.py
@@ -27,9 +27,11 @@ class BaseInterface(Model):
 
 
 class Interface(BaseInterface):
-    def __init__(self, name=None, bond_master=None, auto_negotiation=None, force_up=None, **interface):
+    def __init__(self, name=None, bond_master=None, auto_negotiation=None, force_up=None, recovery_timeout=None,
+                 **interface):
         super(Interface, self).__init__(**interface)
         self.name = name
         self.bond_master = bond_master
         self.auto_negotiation = auto_negotiation
         self.force_up = force_up
+        self.recovery_timeout = recovery_timeout

--- a/netman/core/objects/switch_base.py
+++ b/netman/core/objects/switch_base.py
@@ -129,6 +129,14 @@ class SwitchOperations(BackwardCompatibleSwitchOperations):
         pass
 
     @not_implemented
+    def set_interface_recovery_timeout(self, interface_id, recovery_timeout):
+        pass
+
+    @not_implemented
+    def set_bond_recovery_timeout(self, bond_id, recovery_timeout):
+        pass
+
+    @not_implemented
     def set_interface_native_vlan(self, interface_id, vlan):
         pass
 

--- a/tests/adapters/switches/remote_test.py
+++ b/tests/adapters/switches/remote_test.py
@@ -601,6 +601,7 @@ class RemoteSwitchTest(unittest.TestCase):
         assert_that(interface.trunk_native_vlan, equal_to(2999))
         assert_that(interface.trunk_vlans, equal_to([3000, 3001, 3002]))
         assert_that(interface.force_up, equal_to(None))
+        assert_that(interface.recovery_timeout, equal_to(None))
 
     def test_get_nonexistent_interface_raises(self):
         self.requests_mock.should_receive("get").once().with_args(


### PR DESCRIPTION
support recovery-timeout parameter in interfaces and bonds
   
2 new API:
```
PUT /switches/<hostname>/interfaces/<path:interface_id>/recovery-timeout
PUT /switches/<hostname>/bonds/<bond_number>/recovery-timeout
```